### PR TITLE
feat: add Synthetic provider support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -152,7 +152,7 @@ const FEATURE_META: Array<{
   {
     id: "providerCommands",
     label: "Provider quota commands",
-    description: "Toggle `/anthropic:quotas`, `/codex:quotas`, and `/github:quotas`",
+    description: "Toggle `/anthropic:quotas`, `/codex:quotas`, `/github:quotas`, `/openrouter:quotas`, and `/synthetic:quotas`",
   },
   {
     id: "usageStatus",

--- a/src/extensions/command-quotas/provider-commands.ts
+++ b/src/extensions/command-quotas/provider-commands.ts
@@ -34,5 +34,11 @@ export function getProviderCommandInfo(
         commandName: "openrouter:quotas",
         title: "OpenRouter Quotas",
       };
+    case "synthetic":
+      return {
+        provider,
+        commandName: "synthetic:quotas",
+        title: "Synthetic Quotas",
+      };
   }
 }

--- a/src/lib/quotas.ts
+++ b/src/lib/quotas.ts
@@ -7,6 +7,7 @@ export const SUPPORTED_PROVIDERS: SupportedQuotaProvider[] = [
   "openai-codex",
   "github-copilot",
   "openrouter",
+  "synthetic",
 ];
 
 export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
@@ -14,6 +15,7 @@ export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
   "openai-codex": "OpenAI Codex",
   "github-copilot": "GitHub Copilot",
   openrouter: "OpenRouter",
+  synthetic: "Synthetic",
 };
 
 const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
@@ -21,6 +23,7 @@ const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
   "openai-codex": 60_000,
   "github-copilot": 5 * 60_000,
   openrouter: 60_000,
+  synthetic: 60_000,
 };
 
 type CacheEntry = {

--- a/src/providers/fetch.ts
+++ b/src/providers/fetch.ts
@@ -9,6 +9,7 @@ import {
   parseCodexUsage,
   parseGitHubCopilotUsage,
   parseOpenRouterUsage,
+  parseSyntheticUsage,
 } from "./providers.js";
 
 const FETCH_TIMEOUT_MS = 15_000;
@@ -268,9 +269,28 @@ export async function fetchOpenRouterQuotas(
   );
 }
 
+export async function fetchSyntheticQuotas(
+  _authStorage: AuthStorage,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  const apiKey = process.env.SYNTHETIC_API_KEY;
+  if (!apiKey) return failure("No Synthetic API key found (set SYNTHETIC_API_KEY)", "config");
+
+  const result = await fetchJson(
+    "https://api.synthetic.new/v2/quotas",
+    {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    },
+    signal,
+  );
+  if (!result.ok) return failure(result.message, result.kind);
+  return success("synthetic", parseSyntheticUsage(result.data));
+}
+
 export const PROVIDER_FETCHERS = {
   anthropic: fetchAnthropicQuotas,
   "openai-codex": fetchCodexQuotas,
   "github-copilot": fetchGitHubCopilotQuotas,
   openrouter: fetchOpenRouterQuotas,
+  synthetic: fetchSyntheticQuotas,
 } as const;

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -352,3 +352,88 @@ export function parseOpenRouterUsage(data: any): QuotaWindow[] {
 
   return windows;
 }
+
+export function parseSyntheticUsage(data: any): QuotaWindow[] {
+  const windows: QuotaWindow[] = [];
+
+  // Subscription (requests)
+  if (data?.subscription) {
+    windows.push({
+      provider: "synthetic",
+      label: "Subscription",
+      usedPercent: safePercent(data.subscription.requests, data.subscription.limit),
+      resetsAt: parseDateish(data.subscription.renewsAt),
+      windowSeconds: 30 * 24 * 60 * 60,
+      usedValue: data.subscription.requests,
+      limitValue: data.subscription.limit,
+      showPace: true,
+      nextLabel: "Resets",
+    });
+  }
+
+  // Search hourly
+  if (data?.search?.hourly) {
+    windows.push({
+      provider: "synthetic",
+      label: "Search / hour",
+      usedPercent: safePercent(data.search.hourly.requests, data.search.hourly.limit),
+      resetsAt: parseDateish(data.search.hourly.renewsAt),
+      windowSeconds: 60 * 60,
+      usedValue: data.search.hourly.requests,
+      limitValue: data.search.hourly.limit,
+      showPace: false,
+      nextLabel: "Resets",
+    });
+  }
+
+  // Free tool calls
+  if (data?.freeToolCalls) {
+    windows.push({
+      provider: "synthetic",
+      label: "Free Tools",
+      usedPercent: safePercent(data.freeToolCalls.requests, data.freeToolCalls.limit),
+      resetsAt: parseDateish(data.freeToolCalls.renewsAt),
+      windowSeconds: 30 * 24 * 60 * 60,
+      usedValue: data.freeToolCalls.requests,
+      limitValue: data.freeToolCalls.limit,
+      showPace: true,
+      nextLabel: "Resets",
+    });
+  }
+
+  // Weekly token limit
+  if (data?.weeklyTokenLimit) {
+    const maxCredits = parseFloat(data.weeklyTokenLimit.maxCredits) || 0;
+    const remainingCredits = parseFloat(data.weeklyTokenLimit.remainingCredits) || 0;
+    windows.push({
+      provider: "synthetic",
+      label: "Weekly Tokens",
+      usedPercent: data.weeklyTokenLimit.percentRemaining ?? safePercent(remainingCredits, maxCredits),
+      resetsAt: parseDateish(data.weeklyTokenLimit.nextRegenAt),
+      windowSeconds: 7 * 24 * 60 * 60,
+      usedValue: maxCredits - remainingCredits,
+      limitValue: maxCredits,
+      isCurrency: true,
+      showPace: true,
+      nextLabel: "Regen",
+    });
+  }
+
+  // Rolling 5-hour limit
+  if (data?.rollingFiveHourLimit) {
+    windows.push({
+      provider: "synthetic",
+      label: "5h Limit",
+      usedPercent: data.rollingFiveHourLimit.tickPercent,
+      resetsAt: parseDateish(data.rollingFiveHourLimit.nextTickAt),
+      windowSeconds: 5 * 60 * 60,
+      usedValue: data.rollingFiveHourLimit.max - data.rollingFiveHourLimit.remaining,
+      limitValue: data.rollingFiveHourLimit.max,
+      limited: data.rollingFiveHourLimit.limited,
+      showPace: false,
+      nextLabel: data.rollingFiveHourLimit.limited ? "Limited" : "Resets",
+    });
+  }
+
+  return windows;
+}

--- a/src/types/quotas.ts
+++ b/src/types/quotas.ts
@@ -2,7 +2,8 @@ export type SupportedQuotaProvider =
   | "anthropic"
   | "openai-codex"
   | "github-copilot"
-  | "openrouter";
+  | "openrouter"
+  | "synthetic";
 
 export type QuotasErrorKind =
   | "cancelled"


### PR DESCRIPTION
Adds Synthetic API quota monitoring support to pi-quotas.

- Adds `/synthetic:quotas` command
- Adds Synthetic to the combined `/quotas` dashboard
- Reads API key from `SYNTHETIC_API_KEY` environment variable

The implementation follows the existing provider pattern and displays:
- Subscription requests
- Search hourly limit
- Free tool calls
- Weekly token limit
- Rolling 5-hour limit

Closes: (add Synthetic support to pi-quotas)