### PR TITLE
fix: align quota footer reset precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.2.1] - 2026-05-06
 
 ### Added
 - Synthetic quota monitoring support, including the `/synthetic:quotas` command.
 - Synthetic quota parsing for subscription requests, hourly search limits, free tool calls, weekly tokens, and rolling five-hour limits.
 - Synthetic API quota fetching via the `SYNTHETIC_API_KEY` environment variable.
+
+### Fixed
+- Footer reset times now use minute precision across supported providers, matching quota warning output.
+- Footer status no longer shows misleading reset tags for non-reset windows such as Codex spend cap and credit balances.
+- Elapsed reset times render as `now` instead of `in now`.
 
 ## [0.2.0] - 2026-04-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@latentminds/pi-quotas",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@latentminds/pi-quotas",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "0.61.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latentminds/pi-quotas",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "type": "module",
   "private": false,

--- a/src/extensions/usage-status/format-status.test.ts
+++ b/src/extensions/usage-status/format-status.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { formatWindowStatus, type WindowStatus } from "./format-status.js";
+import type { SupportedQuotaProvider } from "../../types/quotas.js";
+import { formatStatus, toWindowStatus } from "./index.js";
 
 // Minimal fake theme that just returns text with markers for color assertions
 function fakeTheme() {
@@ -10,6 +12,10 @@ function fakeTheme() {
 
 describe("formatWindowStatus", () => {
   const theme = fakeTheme() as any;
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("shows remaining/limit for windows with known limits (GitHub premium)", () => {
     const w: WindowStatus = {
@@ -100,5 +106,103 @@ describe("formatWindowStatus", () => {
     };
     const result = formatWindowStatus(theme, w);
     expect(result).toContain("[dim]5h:");
+  });
+
+  it("renders footer reset times with minute precision for every provider", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-06T05:28:37Z"));
+
+    const providers: Array<{ provider: SupportedQuotaProvider; label: string }> = [
+      { provider: "anthropic", label: "5h" },
+      { provider: "openai-codex", label: "7d" },
+      { provider: "github-copilot", label: "Premium / month" },
+      { provider: "openrouter", label: "Monthly Budget" },
+      { provider: "synthetic", label: "Subscription" },
+    ];
+
+    for (const { provider, label } of providers) {
+      const status = toWindowStatus({
+        provider,
+        label,
+        usedPercent: 50,
+        resetsAt: new Date("2026-05-06T07:47:37Z"),
+        windowSeconds: 5 * 60 * 60,
+        usedValue: 50,
+        limitValue: 100,
+      });
+
+      const result = formatStatus({ ui: { theme } } as any, [status]);
+
+      expect(result).toContain("(↺in 2h19m)");
+      expect(result).not.toContain("(↺in 3h)");
+    }
+  });
+
+  it("omits footer reset tags for windows without a real reset time", () => {
+    const result = formatStatus(
+      { ui: { theme } } as any,
+      [
+        {
+          label: "Spend cap",
+          usedPercent: 0,
+          severity: "none",
+          resetsAt: null,
+          limited: false,
+          usedValue: 0,
+          limitValue: 1,
+        },
+      ],
+    );
+
+    expect(result).toContain("cap:");
+    expect(result).not.toContain("↺");
+    expect(result).not.toContain("soon");
+  });
+
+  it("maps sentinel reset dates to null before rendering status for non-reset provider windows", () => {
+    const windows: Array<{ provider: SupportedQuotaProvider; label: string; isCurrency?: boolean }> = [
+      { provider: "openai-codex", label: "Spend cap" },
+      { provider: "openai-codex", label: "Credits", isCurrency: true },
+      { provider: "openrouter", label: "Credits Remaining", isCurrency: true },
+    ];
+
+    for (const { provider, label, isCurrency } of windows) {
+      const status = toWindowStatus({
+        provider,
+        label,
+        usedPercent: 0,
+        resetsAt: new Date(0),
+        windowSeconds: 0,
+        usedValue: 0,
+        limitValue: 1,
+        limited: false,
+        isCurrency,
+      });
+
+      expect(status.resetsAt).toBeNull();
+    }
+  });
+
+  it("does not prefix elapsed reset times with in", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-06T05:28:37Z"));
+
+    const result = formatStatus(
+      { ui: { theme } } as any,
+      [
+        {
+          label: "5h",
+          usedPercent: 100,
+          severity: "critical",
+          resetsAt: "2026-05-06T05:28:37Z",
+          limited: false,
+          usedValue: 100,
+          limitValue: 100,
+        },
+      ],
+    );
+
+    expect(result).toContain("(↺now)");
+    expect(result).not.toContain("(↺in now)");
   });
 });

--- a/src/extensions/usage-status/index.ts
+++ b/src/extensions/usage-status/index.ts
@@ -11,26 +11,45 @@ import {
 } from "../../config.js";
 import {
   fetchProviderQuotas,
-  formatResetTime,
   isSupportedProvider,
 } from "../../lib/quotas.js";
 import {
   assessWindow,
+  formatTimeRemaining,
 } from "../../utils/quotas-severity.js";
+import type { QuotaWindow } from "../../types/quotas.js";
 import { formatWindowStatus, type WindowStatus } from "./format-status.js";
 
 const EXTENSION_ID = "pi-quotas-usage";
 const REFRESH_INTERVAL_MS = 60_000;
 
-function formatStatus(ctx: ExtensionContext, windows: WindowStatus[]): string {
+function formatFooterResetTime(resetsAt: string): string {
+  const remaining = formatTimeRemaining(new Date(resetsAt));
+  return remaining === "now" ? "now" : `in ${remaining}`;
+}
+
+export function formatStatus(ctx: Pick<ExtensionContext, "ui">, windows: WindowStatus[]): string {
   const theme = ctx.ui.theme;
   return windows
     .map((w) => {
       const core = formatWindowStatus(theme, w);
-      const reset = w.resetsAt ? theme.fg("dim", ` (↺${formatResetTime(w.resetsAt)})`) : "";
+      const reset = w.resetsAt ? theme.fg("dim", ` (↺${formatFooterResetTime(w.resetsAt)})`) : "";
       return `${core}${reset}`;
     })
     .join(" ");
+}
+
+export function toWindowStatus(window: QuotaWindow): WindowStatus {
+  return {
+    label: window.label,
+    usedPercent: window.usedPercent,
+    severity: assessWindow(window).severity,
+    resetsAt: window.resetsAt.getTime() > 0 ? window.resetsAt.toISOString() : null,
+    limited: window.limited ?? false,
+    isCurrency: window.isCurrency,
+    usedValue: window.usedValue,
+    limitValue: window.limitValue,
+  };
 }
 
 function createStatusRefresher() {
@@ -54,16 +73,7 @@ function createStatusRefresher() {
         ctx.ui.setStatus(EXTENSION_ID, ctx.ui.theme.fg("warning", "usage unavailable"));
         return;
       }
-      const windows: WindowStatus[] = result.data.windows.map((window) => ({
-        label: window.label,
-        usedPercent: window.usedPercent,
-        severity: assessWindow(window).severity,
-        resetsAt: window.resetsAt.toISOString(),
-        limited: window.limited ?? false,
-        isCurrency: window.isCurrency,
-        usedValue: window.usedValue,
-        limitValue: window.limitValue,
-      }));
+      const windows: WindowStatus[] = result.data.windows.map(toWindowStatus);
       lastStatus = windows;
       ctx.ui.setStatus(EXTENSION_ID, formatStatus(ctx, windows));
     } catch {


### PR DESCRIPTION
## Summary
- Fix footer reset timestamps to use minute precision across supported quota providers.
- Suppress misleading reset tags for non-reset quota windows such as Codex spend cap/credits and OpenRouter credits remaining.
- Bump package version to 0.2.1 and document the patch release.

## Verification
- `npm test` — 5 files passed, 50 tests passed
- `npm run typecheck` — passed
- `npm pack --dry-run` — produced @latentminds/pi-quotas@0.2.1 tarball preview

## Notes
- The formatting path is provider-agnostic and regression tests cover Anthropic, Codex, GitHub Copilot, and OpenRouter reset precision.
