### PR TITLE
docs: document Synthetic provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Synthetic quota monitoring support, including the `/synthetic:quotas` command.
+- Synthetic quota parsing for subscription requests, hourly search limits, free tool calls, weekly tokens, and rolling five-hour limits.
+- Synthetic API quota fetching via the `SYNTHETIC_API_KEY` environment variable.
+
 ## [0.2.0] - 2026-04-22
 
 ### Added


### PR DESCRIPTION
## Summary
- Document the newly merged Synthetic provider support in `CHANGELOG.md`.
- Capture the new `/synthetic:quotas` command, quota parsing coverage, and `SYNTHETIC_API_KEY` credential path under an Unreleased section.

## Verification
- `npm test` — 5 files passed, 46 tests passed
- `npm run typecheck` — passed
- `npm pack --dry-run` — tarball preview completed for current package metadata

## Notes
- This PR intentionally does not bump `package.json`; the package version is still `0.2.0` on `main`, and the separate footer reset precision PR handles its own `0.2.1` patch bump.
