### PR TITLE
fix: hide Anthropic subscription windows from footer status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Footer reset times now use minute precision across supported providers, matching quota warning output.
 - Footer status no longer shows misleading reset tags for non-reset windows such as Codex spend cap and credit balances.
+- Anthropic subscription quota windows are hidden from the footer status line while remaining available in quota dashboards and warnings.
 - Elapsed reset times render as `now` instead of `in now`.
 
 ## [0.2.0] - 2026-04-22

--- a/src/extensions/usage-status/format-status.test.ts
+++ b/src/extensions/usage-status/format-status.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { formatWindowStatus, type WindowStatus } from "./format-status.js";
 import type { SupportedQuotaProvider } from "../../types/quotas.js";
-import { formatStatus, toWindowStatus } from "./index.js";
+import { formatStatus, formatStatusForFooter, toStatusWindows, toWindowStatus } from "./index.js";
 
 // Minimal fake theme that just returns text with markers for color assertions
 function fakeTheme() {
@@ -181,6 +181,46 @@ describe("formatWindowStatus", () => {
 
       expect(status.resetsAt).toBeNull();
     }
+  });
+
+  it("clears the footer status when filtering removes all windows", () => {
+    expect(formatStatusForFooter({ ui: { theme } } as any, [])).toBeUndefined();
+  });
+
+  it("filters Anthropic subscription windows from footer status while keeping extra usage", () => {
+    const windows = toStatusWindows([
+      {
+        provider: "anthropic",
+        label: "5h",
+        usedPercent: 10,
+        resetsAt: new Date("2026-05-06T07:47:37Z"),
+        windowSeconds: 5 * 60 * 60,
+        usedValue: 10,
+        limitValue: 100,
+      },
+      {
+        provider: "anthropic",
+        label: "7d Sonnet",
+        usedPercent: 20,
+        resetsAt: new Date("2026-05-06T07:47:37Z"),
+        windowSeconds: 7 * 24 * 60 * 60,
+        usedValue: 20,
+        limitValue: 100,
+      },
+      {
+        provider: "anthropic",
+        label: "Extra (USD)",
+        usedPercent: 30,
+        resetsAt: new Date("2026-06-01T00:00:00Z"),
+        windowSeconds: 30 * 24 * 60 * 60,
+        usedValue: 30,
+        limitValue: 100,
+        isCurrency: true,
+      },
+    ]);
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({ label: "Extra (USD)" });
   });
 
   it("does not prefix elapsed reset times with in", () => {

--- a/src/extensions/usage-status/index.ts
+++ b/src/extensions/usage-status/index.ts
@@ -39,6 +39,21 @@ export function formatStatus(ctx: Pick<ExtensionContext, "ui">, windows: WindowS
     .join(" ");
 }
 
+const ANTHROPIC_SUBSCRIPTION_WINDOW_LABELS = new Set([
+  "5h",
+  "7d",
+  "7d Sonnet",
+  "7d Opus",
+  "7d Opus (legacy)",
+]);
+
+function shouldShowInStatus(window: QuotaWindow): boolean {
+  return !(
+    window.provider === "anthropic" &&
+    ANTHROPIC_SUBSCRIPTION_WINDOW_LABELS.has(window.label)
+  );
+}
+
 export function toWindowStatus(window: QuotaWindow): WindowStatus {
   return {
     label: window.label,
@@ -50,6 +65,18 @@ export function toWindowStatus(window: QuotaWindow): WindowStatus {
     usedValue: window.usedValue,
     limitValue: window.limitValue,
   };
+}
+
+export function toStatusWindows(windows: QuotaWindow[]): WindowStatus[] {
+  return windows.filter(shouldShowInStatus).map(toWindowStatus);
+}
+
+export function formatStatusForFooter(
+  ctx: Pick<ExtensionContext, "ui">,
+  windows: WindowStatus[],
+): string | undefined {
+  if (windows.length === 0) return undefined;
+  return formatStatus(ctx, windows);
 }
 
 function createStatusRefresher() {
@@ -73,9 +100,10 @@ function createStatusRefresher() {
         ctx.ui.setStatus(EXTENSION_ID, ctx.ui.theme.fg("warning", "usage unavailable"));
         return;
       }
-      const windows: WindowStatus[] = result.data.windows.map(toWindowStatus);
-      lastStatus = windows;
-      ctx.ui.setStatus(EXTENSION_ID, formatStatus(ctx, windows));
+      const windows: WindowStatus[] = toStatusWindows(result.data.windows);
+      const status = formatStatusForFooter(ctx, windows);
+      lastStatus = status === undefined ? undefined : windows;
+      ctx.ui.setStatus(EXTENSION_ID, status);
     } catch {
       ctx.ui.setStatus(EXTENSION_ID, ctx.ui.theme.fg("warning", "usage unavailable"));
     } finally {
@@ -114,7 +142,7 @@ function createStatusRefresher() {
     },
     renderLast(ctx: ExtensionContext): boolean {
       if (!lastStatus || !ctx.hasUI) return false;
-      ctx.ui.setStatus(EXTENSION_ID, formatStatus(ctx, lastStatus));
+      ctx.ui.setStatus(EXTENSION_ID, formatStatusForFooter(ctx, lastStatus));
       return true;
     },
   };

--- a/src/providers/parse.test.ts
+++ b/src/providers/parse.test.ts
@@ -48,6 +48,8 @@ describe("parseAnthropicUsage", () => {
     const extra = windows.find((w) => w.label === "Extra (AUD)");
     expect(extra).toBeDefined();
     expect(extra).toMatchObject({
+      provider: "anthropic",
+      label: "Extra (AUD)",
       isCurrency: true,
       usedPercent: 71.83,
       usedValue: 215.48,


### PR DESCRIPTION
## Summary
- Adapt Pierre Hugo's fork PR (pierrekin/pi-quotas#1) to hide Anthropic subscription quota windows from the Pi footer status line.
- Keep Anthropic subscription windows available to the quota dashboard and quota warning logic by leaving parser output intact.
- Clear the footer status when filtering leaves no displayable windows, avoiding a blank footer entry.
- Update the 0.2.1 changelog entry for the pending release.

## Attribution
- Based on Pierre Hugo's change: https://github.com/pierrekin/pi-quotas/pull/1
- Commit author preserved as Pierre Hugo.

## Verification
- `npm test` — 5 files passed, 52 tests passed
- `npm run typecheck` — passed
- `npm pack --dry-run` — tarball preview completed for @latentminds/pi-quotas@0.2.1
