### PR TITLE
fix: make quota fetches non-blocking during Pi startup and turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- Pi startup and turn handling no longer wait for footer quota refreshes or quota warning checks; remote quota requests now run in the background.
+
 ## [0.2.4] - 2026-05-06
 
 ### Added

--- a/src/extensions/quota-warnings/index.ts
+++ b/src/extensions/quota-warnings/index.ts
@@ -85,6 +85,12 @@ export default async function (pi: ExtensionAPI) {
     ctx.ui.notify(`${providerName} quota warning:\n${lines.join("\n")}`, level);
   }
 
+  function scheduleCheck(ctx: ExtensionContext, onlyNew: boolean): void {
+    void check(ctx, onlyNew).catch(() => {
+      // Quota warnings are opportunistic; never let a failed quota check block Pi events.
+    });
+  }
+
   pi.events.on(QUOTAS_CONFIG_UPDATED_EVENT, (data: unknown) => {
     enabled = (data as QuotasConfigUpdatedPayload).config.quotaWarnings;
     if (!enabled) {
@@ -93,21 +99,21 @@ export default async function (pi: ExtensionAPI) {
     }
     if (currentContext) {
       clearAlertState();
-      void check(currentContext, false);
+      scheduleCheck(currentContext, false);
     }
   });
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", (_event, ctx) => {
     currentContext = ctx;
     clearAlertState();
     if (!enabled) return;
-    await check(ctx, false);
+    scheduleCheck(ctx, false);
   });
 
-  pi.on("turn_end", async (_event, ctx) => {
+  pi.on("turn_end", (_event, ctx) => {
     currentContext = ctx;
     if (!enabled) return;
-    await check(ctx, true);
+    scheduleCheck(ctx, true);
   });
 
   pi.on("model_select", async (_event, ctx) => {

--- a/src/extensions/usage-status/index.ts
+++ b/src/extensions/usage-status/index.ts
@@ -176,6 +176,12 @@ export default async function (pi: ExtensionAPI) {
     }
   });
 
+  function scheduleRefresh(ctx: ExtensionContext): void {
+    void refresher.refreshFor(ctx).catch(() => {
+      if (ctx.hasUI) ctx.ui.setStatus(EXTENSION_ID, ctx.ui.theme.fg("warning", "usage unavailable"));
+    });
+  }
+
   pi.events.on(QUOTAS_CONFIG_UPDATED_EVENT, (data: unknown) => {
     const config = (data as QuotasConfigUpdatedPayload).config;
     enabled = config.usageStatus;
@@ -186,7 +192,7 @@ export default async function (pi: ExtensionAPI) {
     }
     if (currentContext) {
       refresher.start();
-      void refresher.refreshFor(currentContext);
+      scheduleRefresh(currentContext);
     }
   });
 
@@ -198,7 +204,7 @@ export default async function (pi: ExtensionAPI) {
     return deferToSynthetic && syntheticUsageActive && provider === "synthetic";
   }
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", (_event, ctx) => {
     currentContext = ctx;
     if (!enabled) return;
     if (shouldDeferToSynthetic(ctx.model?.provider)) {
@@ -206,17 +212,17 @@ export default async function (pi: ExtensionAPI) {
       return;
     }
     refresher.start();
-    await refresher.refreshFor(ctx);
+    scheduleRefresh(ctx);
   });
 
-  pi.on("turn_end", async (_event, ctx) => {
+  pi.on("turn_end", (_event, ctx) => {
     currentContext = ctx;
     if (!enabled) return;
     if (shouldDeferToSynthetic(ctx.model?.provider)) return;
-    await refresher.refreshFor(ctx);
+    scheduleRefresh(ctx);
   });
 
-  pi.on("model_select", async (_event, ctx) => {
+  pi.on("model_select", (_event, ctx) => {
     currentContext = ctx;
     if (!enabled) {
       refresher.stop(ctx);
@@ -226,7 +232,7 @@ export default async function (pi: ExtensionAPI) {
       ctx.ui.setStatus(EXTENSION_ID, undefined);
       return;
     }
-    await refresher.refreshFor(ctx);
+    scheduleRefresh(ctx);
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {


### PR DESCRIPTION
## Problem

Pi startup was slowed down because `pi-quotas` awaited remote HTTP quota fetches inside `session_start`, `turn_end`, and `model_select` event handlers. Each provider call can take up to 15 s (timeout), and the usage-status and quota-warnings extensions ran them sequentially before returning control to Pi.

## Fix

Both extensions now schedule their quota fetches as fire-and-forget promises (`void promise.catch(…)`) so lifecycle handlers return immediately. Quota data still loads and renders as soon as the background requests complete.

### Changes

- **`src/extensions/usage-status/index.ts`** — added `scheduleRefresh()` helper; `session_start`, `turn_end`, and `model_select` handlers no longer `await` the fetch. Errors are caught and displayed as "usage unavailable" in the footer.
- **`src/extensions/quota-warnings/index.ts`** — added `scheduleCheck()` helper; `session_start` and `turn_end` handlers no longer `await` the quota check. Warnings are opportunistic so failures are silently swallowed.
- **`CHANGELOG.md`** — unreleased entry documenting the fix.

### Verification

- `npm run typecheck` — passes
- `npm test` — 57/57 tests pass