### PR TITLE
fix: use GitHub OAuth token for Copilot quota checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Pi startup and turn handling no longer wait for footer quota refreshes or quota warning checks; remote quota requests now run in the background.
+- GitHub Copilot quota checks now use Pi's stored GitHub OAuth token for the `/copilot_internal/user` endpoint, fixing `401 Bad credentials` failures with Pi 0.74 auth credentials. Reported by @6aKa in #8.
 
 ## [0.2.4] - 2026-05-06
 

--- a/src/providers/fetch.test.ts
+++ b/src/providers/fetch.test.ts
@@ -1,7 +1,9 @@
+import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchAnthropicQuotasWithToken,
   fetchCodexQuotasWithToken,
+  fetchGitHubCopilotQuotas,
   fetchGitHubCopilotQuotasWithToken,
   fetchOpenRouterQuotasWithToken,
 } from "./fetch.js";
@@ -134,6 +136,44 @@ describe("fetchGitHubCopilotQuotasWithToken", () => {
     const result = await fetchGitHubCopilotQuotasWithToken("gh-token");
     expect(result.success).toBe(true);
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the stored GitHub OAuth refresh token for Pi 0.74 Copilot quota checks", async () => {
+    const auth = AuthStorage.inMemory({
+      "github-copilot": {
+        type: "oauth",
+        refresh: "ghu-refresh-token",
+        access: "tid=abc;proxy-ep=proxy.individual.githubcopilot.com;exp=1778611280",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      const authorization = new Headers(init?.headers).get("authorization");
+      if (authorization === "Bearer ghu-refresh-token") {
+        return new Response(
+          JSON.stringify({
+            quota_reset_date: "2026-05-01T00:00:00Z",
+            quota_snapshots: {
+              premium_interactions: { entitlement: 300, remaining: 210 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
+    }) as any;
+
+    const result = await fetchGitHubCopilotQuotas(auth);
+
+    expect(result.success).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/copilot_internal/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer ghu-refresh-token" }),
+      }),
+    );
   });
 });
 

--- a/src/providers/fetch.ts
+++ b/src/providers/fetch.ts
@@ -179,6 +179,32 @@ async function tryGitHubUserEndpoint(
   );
 }
 
+function githubOAuthToken(authStorage: AuthStorage): string | undefined {
+  // Pi's GitHub Copilot OAuth credential stores the GitHub OAuth token in
+  // `refresh`; `access` is a Copilot proxy token (tid=...;proxy-ep=...) that
+  // is valid for model calls but rejected by api.github.com quota endpoints.
+  const credential = authStorage.get("github-copilot") as any;
+  if (credential?.type !== "oauth") return undefined;
+  return typeof credential.refresh === "string" && credential.refresh.length > 0
+    ? credential.refresh
+    : undefined;
+}
+
+async function fetchGitHubCopilotQuotasWithGitHubToken(
+  githubToken: string | undefined,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  if (!githubToken) return failure("No GitHub Copilot OAuth token found", "config");
+
+  const bearerUsage = await tryGitHubUserEndpoint(`Bearer ${githubToken}`, signal);
+  if (bearerUsage.ok) return success("github-copilot", parseGitHubCopilotUsage(bearerUsage.data));
+
+  const tokenUsage = await tryGitHubUserEndpoint(`token ${githubToken}`, signal);
+  if (tokenUsage.ok) return success("github-copilot", parseGitHubCopilotUsage(tokenUsage.data));
+
+  return failure(bearerUsage.message, bearerUsage.kind);
+}
+
 export async function fetchGitHubCopilotQuotasWithToken(
   accessToken: string | undefined,
   signal?: AbortSignal,
@@ -234,6 +260,18 @@ export async function fetchGitHubCopilotQuotas(
   authStorage: AuthStorage,
   signal?: AbortSignal,
 ): Promise<QuotasResult> {
+  const oauthResult = await fetchGitHubCopilotQuotasWithGitHubToken(
+    githubOAuthToken(authStorage),
+    signal,
+  );
+  if (
+    oauthResult.success ||
+    oauthResult.error.kind === "cancelled" ||
+    oauthResult.error.kind === "timeout"
+  ) {
+    return oauthResult;
+  }
+
   return fetchGitHubCopilotQuotasWithToken(
     await providerAccessToken(authStorage, "github-copilot"),
     signal,


### PR DESCRIPTION
## Summary
- Use Pi's raw stored GitHub OAuth token (`github-copilot.refresh`) for Copilot quota `/copilot_internal/user` checks.
- Keep the existing access-token exchange/direct usage and `gh auth token` fallback path for older or nonstandard credentials.
- Add a regression test for the Pi 0.74 credential shape where `access` is a Copilot proxy token (`tid=...;proxy-ep=...`).
- Add an Unreleased changelog entry with reporter attribution.

## Verification
- `npm test` — 5 test files passed, 58 tests passed.
- `npm run typecheck` — passed.
- Reviewer subagent found no Critical/Important/Minor issues.

## Attribution
Reported by @6aKa: https://github.com/6aKa

Fixes #8
