### PR TITLE
fix: correct quota dashboard severity and rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Quotas dashboard footer now shows the running `pi-quotas` package version.
+- Dashboard render tests cover version display and pace-marker edge cases.
+
+### Fixed
+- Pace-aware quota windows now still switch to warning/high/critical colors at absolute 80%/90%/100% usage thresholds, preventing high-usage monthly quotas from staying green.
+- Quotas dashboard progress bars no longer show stray accent-colored pace markers inside filled warning bars or on zero-usage bars.
+
 ## [0.2.5] - 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [0.2.5] - 2026-05-14
 
 ### Fixed
 - Pi startup and turn handling no longer wait for footer quota refreshes or quota warning checks; remote quota requests now run in the background.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@latentminds/pi-quotas",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@latentminds/pi-quotas",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "0.61.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latentminds/pi-quotas",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "MIT",
   "type": "module",
   "private": false,

--- a/src/extensions/command-quotas/components/quotas-display.test.ts
+++ b/src/extensions/command-quotas/components/quotas-display.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { QuotasComponent } from "./quotas-display.js";
+
+const ansi = {
+  accent: "\x1b[32m",
+  border: "\x1b[36m",
+  dim: "\x1b[2m",
+  error: "\x1b[31m",
+  muted: "\x1b[90m",
+  success: "\x1b[32m",
+  warning: "\x1b[33m",
+} as const;
+
+function fakeTheme() {
+  return {
+    bold: (text: string) => text,
+    fg: (color: keyof typeof ansi, text: string) => `${ansi[color] ?? ""}${text}\x1b[0m`,
+    getFgAnsi: (color: keyof typeof ansi) => ansi[color] ?? "",
+  };
+}
+
+function makeComponent(): QuotasComponent {
+  return new QuotasComponent(
+    fakeTheme() as any,
+    { requestRender: () => {} } as any,
+    "Quotas",
+    () => {},
+    () => {},
+  );
+}
+
+describe("QuotasComponent", () => {
+  it("renders the pi-quotas package version in the dashboard footer", () => {
+    const component = makeComponent();
+    component.setState({ type: "loaded", snapshots: [] });
+
+    expect(component.render(70).join("\n")).toContain("pi-quotas v0.2.5");
+  });
+
+  it("does not render an accent-colored pace marker inside filled warning bars", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T13:42:11Z"));
+
+    const component = makeComponent();
+    component.setState({
+      type: "loaded",
+      snapshots: [
+        {
+          provider: "github-copilot",
+          result: {
+            success: true,
+            data: {
+              provider: "github-copilot",
+              windows: [
+                {
+                  provider: "github-copilot",
+                  label: "Premium / month",
+                  usedPercent: 83,
+                  resetsAt: new Date("2026-06-01T10:00:00Z"),
+                  windowSeconds: 31 * 24 * 3600,
+                  usedValue: 249,
+                  limitValue: 300,
+                  showPace: true,
+                  nextLabel: "Resets",
+                  nextAmount: "overage allowed",
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    const output = component.render(70).join("\n");
+
+    expect(output).toContain("51/300 left");
+    expect(output).not.toContain(`${ansi.accent}|`);
+
+    vi.useRealTimers();
+  });
+
+  it("does not render a pace marker for zero-usage windows", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T13:49:29Z"));
+
+    const component = makeComponent();
+    component.setState({
+      type: "loaded",
+      snapshots: [
+        {
+          provider: "synthetic",
+          result: {
+            success: true,
+            data: {
+              provider: "synthetic",
+              windows: [
+                {
+                  provider: "synthetic",
+                  label: "Credits / week",
+                  usedPercent: 0,
+                  resetsAt: new Date("2026-05-14T16:40:29Z"),
+                  windowSeconds: 7 * 24 * 3600,
+                  usedValue: 0,
+                  limitValue: 24,
+                  isCurrency: true,
+                  showPace: true,
+                  nextLabel: "Next regen",
+                  nextAmount: "+$0.48",
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    const output = component.render(70).join("\n");
+
+    expect(output).toContain("$0.00 / $24.00");
+    expect(output).not.toContain("|");
+
+    vi.useRealTimers();
+  });
+});

--- a/src/extensions/command-quotas/components/quotas-display.ts
+++ b/src/extensions/command-quotas/components/quotas-display.ts
@@ -2,6 +2,7 @@ import type { Theme } from "@mariozechner/pi-coding-agent";
 import { DynamicBorder } from "@mariozechner/pi-coding-agent";
 import type { Component } from "@mariozechner/pi-tui";
 import { Loader, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
+import pkg from "../../../../package.json" with { type: "json" };
 import { PROVIDER_LABELS } from "../../../lib/quotas.js";
 import type { QuotasResult, SupportedQuotaProvider } from "../../../types/quotas.js";
 import {
@@ -19,10 +20,6 @@ type QuotasState =
   | { type: "loading" }
   | { type: "loaded"; snapshots: Snapshot[] };
 
-function fgAnsiToBg(fgAnsi: string): string {
-  return fgAnsi.split("[38;").join("[48;").replace(/\[3([0-9])m/g, "[4$1m");
-}
-
 function renderProgressBar(
   percent: number,
   width: number,
@@ -33,6 +30,7 @@ function renderProgressBar(
   const clamped = Math.max(0, Math.min(100, Math.round(percent)));
   const filled = Math.round((clamped / 100) * width);
   const showPace =
+    percent > 0 &&
     pacePercent !== null &&
     pacePercent !== undefined &&
     pacePercent >= 5 &&
@@ -44,11 +42,10 @@ function renderProgressBar(
   const parts: string[] = [];
   for (let idx = 0; idx < width; idx++) {
     if (paceIndex !== null && idx === paceIndex) {
-      const markerColor = idx < filled ? "accent" : fillColor;
       if (idx < filled) {
-        parts.push(`${fgAnsiToBg(theme.getFgAnsi(fillColor))}${theme.getFgAnsi(markerColor)}|${reset}`);
+        parts.push(theme.fg(fillColor, "█"));
       } else {
-        parts.push(theme.fg(markerColor, "|"));
+        parts.push(theme.fg(fillColor, "|"));
       }
     } else if (idx < filled) {
       parts.push(theme.fg(fillColor, "█"));
@@ -123,7 +120,7 @@ export class QuotasComponent implements Component {
     }
 
     lines.push("");
-    lines.push(this.theme.fg("dim", "  r to refresh  q/Esc to close"));
+    lines.push(this.theme.fg("dim", `  pi-quotas v${pkg.version}  ·  r to refresh  q/Esc to close`));
     lines.push(...border.render(width));
     return lines;
   }

--- a/src/utils/quotas-severity.test.ts
+++ b/src/utils/quotas-severity.test.ts
@@ -74,13 +74,33 @@ describe("assessWindow", () => {
     expect(assessWindow(w).severity).toBe("critical");
   });
 
+  it("warns for pace-aware windows once absolute usage reaches 80%", () => {
+    const now = Date.now();
+    const monthSeconds = 31 * 24 * 3600;
+    const w = makeWindow({
+      provider: "github-copilot",
+      label: "Premium / month",
+      usedPercent: 83,
+      usedValue: 249,
+      limitValue: 300,
+      showPace: true,
+      windowSeconds: monthSeconds,
+      // Screenshot repro: 51/300 left with reset in about 428h35m in a 31-day
+      // monthly window. Dynamic pace alone projects just under warning, but
+      // only 17% remains, so low-quota color should still be amber.
+      resetsAt: new Date(now + ((428 * 60 + 35) * 60 * 1000)),
+    });
+
+    expect(assessWindow(w).severity).toBe("warning");
+  });
+
   it("returns warning when projected exceeds dynamic warn threshold", () => {
     const w = makeWindow({
-      usedPercent: 95,
+      usedPercent: 79,
       showPace: true,
       paceScale: 1,
       windowSeconds: 3600,
-      resetsAt: new Date(Date.now() + 1800 * 1000),
+      resetsAt: new Date(Date.now() + 2520 * 1000),
     });
     expect(assessWindow(w).severity).toBe("warning");
   });

--- a/src/utils/quotas-severity.ts
+++ b/src/utils/quotas-severity.ts
@@ -53,11 +53,24 @@ export function getProjectedPercent(
   return Math.max(0, (usedPercent / effectivePace) * 100);
 }
 
+function absoluteUsageSeverity(window: QuotaWindow, percent: number): RiskSeverity {
+  if (window.limited || percent >= 100) return "critical";
+  if (percent >= 90) return "high";
+  if (percent >= 80) return "warning";
+  return "none";
+}
+
+function maxSeverity(a: RiskSeverity, b: RiskSeverity): RiskSeverity {
+  const order: RiskSeverity[] = ["none", "warning", "high", "critical"];
+  return order[Math.max(order.indexOf(a), order.indexOf(b))] ?? "none";
+}
+
 export function assessWindow(window: QuotaWindow): RiskAssessment {
   const rawPace = window.showPace ? getPacePercent(window) : null;
   const pacePercent =
     rawPace !== null ? rawPace * (window.paceScale ?? 1) : null;
   const projectedPercent = getProjectedPercent(window.usedPercent, pacePercent);
+  const absoluteSeverity = absoluteUsageSeverity(window, window.usedPercent);
 
   let progress: number | null = null;
   if (pacePercent !== null) progress = pacePercent / 100;
@@ -70,10 +83,7 @@ export function assessWindow(window: QuotaWindow): RiskAssessment {
   };
 
   if (progress === null) {
-    let severity: RiskSeverity = "none";
-    if (window.limited || projectedPercent >= 100) severity = "critical";
-    else if (projectedPercent >= 90) severity = "high";
-    else if (projectedPercent >= 80) severity = "warning";
+    const severity = absoluteUsageSeverity(window, projectedPercent);
 
     return {
       ...base,
@@ -121,7 +131,7 @@ export function assessWindow(window: QuotaWindow): RiskAssessment {
     warnProjectedPercent,
     highProjectedPercent,
     criticalProjectedPercent,
-    severity,
+    severity: maxSeverity(severity, absoluteSeverity),
   };
 }
 


### PR DESCRIPTION
## Summary
- Fix pace-aware quota severity so absolute 80%/90%/100% usage thresholds still drive warning/high/critical colors.
- Fix Quotas dashboard progress bars so pace markers do not render as stray accent-colored lines inside filled warning bars or on zero-usage bars.
- Add the running package version to the Quotas dashboard footer as `pi-quotas v0.2.5`.
- Update the changelog under `[Unreleased]`.

## Verification
- `npm test` — 6 files, 62 tests passed
- `npm run typecheck` — passed