### PR TITLE
feat: token usage tracking + OpenCode Go provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "extensions": [
       "./src/extensions/core/index.ts",
       "./src/extensions/command-quotas/index.ts",
+      "./src/extensions/command-tokens/index.ts",
       "./src/extensions/usage-status/index.ts",
       "./src/extensions/quota-warnings/index.ts"
     ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,222 +6,244 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import pkg from "../package.json" with { type: "json" };
 
 export type QuotasFeatureId =
-  | "quotasCommand"
-  | "providerCommands"
-  | "usageStatus"
-  | "quotaWarnings"
-  | "deferToSynthetic";
+	| "quotasCommand"
+	| "providerCommands"
+	| "usageStatus"
+	| "tokenStatus"
+	| "quotaWarnings"
+	| "deferToSynthetic";
 
 export const QUOTAS_EXTENSIONS_REQUEST_EVENT =
-  "quotas:extensions:request" as const;
+	"quotas:extensions:request" as const;
 export const QUOTAS_EXTENSIONS_REGISTER_EVENT =
-  "quotas:extensions:register" as const;
-export const QUOTAS_CONFIG_UPDATED_EVENT =
-  "quotas:config:updated" as const;
+	"quotas:extensions:register" as const;
+export const QUOTAS_CONFIG_UPDATED_EVENT = "quotas:config:updated" as const;
 
 export interface QuotasExtensionsRegisterPayload {
-  feature: QuotasFeatureId;
+	feature: QuotasFeatureId;
 }
 
 export interface QuotasConfig {
-  configVersion?: string;
-  quotasCommand?: boolean;
-  providerCommands?: boolean;
-  usageStatus?: boolean;
-  quotaWarnings?: boolean;
-  /** When true and pi-synthetic's usage footer is active, hide pi-quotas' Synthetic footer. */
-  deferToSynthetic?: boolean;
+	configVersion?: string;
+	quotasCommand?: boolean;
+	providerCommands?: boolean;
+	usageStatus?: boolean;
+	tokenStatus?: boolean;
+	quotaWarnings?: boolean;
+	/** When true and pi-synthetic's usage footer is active, hide pi-quotas' Synthetic footer. */
+	deferToSynthetic?: boolean;
 }
 
 export interface ResolvedQuotasConfig {
-  configVersion: string;
-  quotasCommand: boolean;
-  providerCommands: boolean;
-  usageStatus: boolean;
-  quotaWarnings: boolean;
-  deferToSynthetic: boolean;
+	configVersion: string;
+	quotasCommand: boolean;
+	providerCommands: boolean;
+	usageStatus: boolean;
+	quotaWarnings: boolean;
+	deferToSynthetic: boolean;
 }
 
 const DEFAULT_CONFIG: ResolvedQuotasConfig = {
-  configVersion: pkg.version,
-  quotasCommand: true,
-  providerCommands: true,
-  usageStatus: true,
-  quotaWarnings: true,
-  deferToSynthetic: true,
+	configVersion: pkg.version,
+	quotasCommand: true,
+	providerCommands: true,
+	usageStatus: true,
+	quotaWarnings: true,
+	deferToSynthetic: true,
 };
 
 let pendingMigrationNotice = false;
 
 function markMigrationNoticePending(): void {
-  pendingMigrationNotice = true;
+	pendingMigrationNotice = true;
 }
 
 export function hasPendingMigrationNotice(): boolean {
-  return pendingMigrationNotice;
+	return pendingMigrationNotice;
 }
 
 export function clearPendingMigrationNotice(): void {
-  pendingMigrationNotice = false;
+	pendingMigrationNotice = false;
 }
 
 class QuotasConfigStore {
-  private config: ResolvedQuotasConfig = DEFAULT_CONFIG;
-  private cwd = process.cwd();
+	private config: ResolvedQuotasConfig = DEFAULT_CONFIG;
+	private cwd = process.cwd();
 
-  private globalPath(): string {
-    return join(homedir(), ".pi", "agent", "extensions", "quotas.json");
-  }
+	private globalPath(): string {
+		return join(homedir(), ".pi", "agent", "extensions", "quotas.json");
+	}
 
-  private localPath(): string {
-    return join(this.cwd, ".pi", "quotas.json");
-  }
+	private localPath(): string {
+		return join(this.cwd, ".pi", "quotas.json");
+	}
 
-  private resolve(input?: QuotasConfig): ResolvedQuotasConfig {
-    return {
-      configVersion: input?.configVersion ?? DEFAULT_CONFIG.configVersion,
-      quotasCommand: input?.quotasCommand ?? DEFAULT_CONFIG.quotasCommand,
-      providerCommands: input?.providerCommands ?? DEFAULT_CONFIG.providerCommands,
-      usageStatus: input?.usageStatus ?? DEFAULT_CONFIG.usageStatus,
-      quotaWarnings: input?.quotaWarnings ?? DEFAULT_CONFIG.quotaWarnings,
-      deferToSynthetic: input?.deferToSynthetic ?? DEFAULT_CONFIG.deferToSynthetic,
-    };
-  }
+	private resolve(input?: QuotasConfig): ResolvedQuotasConfig {
+		return {
+			configVersion: input?.configVersion ?? DEFAULT_CONFIG.configVersion,
+			quotasCommand: input?.quotasCommand ?? DEFAULT_CONFIG.quotasCommand,
+			providerCommands:
+				input?.providerCommands ?? DEFAULT_CONFIG.providerCommands,
+			usageStatus: input?.usageStatus ?? DEFAULT_CONFIG.usageStatus,
+			quotaWarnings: input?.quotaWarnings ?? DEFAULT_CONFIG.quotaWarnings,
+			deferToSynthetic:
+				input?.deferToSynthetic ?? DEFAULT_CONFIG.deferToSynthetic,
+		};
+	}
 
-  private async readConfig(path: string): Promise<QuotasConfig | undefined> {
-    try {
-      const data = JSON.parse(await readFile(path, "utf8")) as QuotasConfig;
-      return data;
-    } catch {
-      return undefined;
-    }
-  }
+	private async readConfig(path: string): Promise<QuotasConfig | undefined> {
+		try {
+			const data = JSON.parse(await readFile(path, "utf8")) as QuotasConfig;
+			return data;
+		} catch {
+			return undefined;
+		}
+	}
 
-  async load(cwd = process.cwd()): Promise<void> {
-    this.cwd = cwd;
-    const global = await this.readConfig(this.globalPath());
-    const local = await this.readConfig(this.localPath());
-    const merged = { ...global, ...local };
-    if (!global && !local) markMigrationNoticePending();
-    this.config = this.resolve(merged);
-  }
+	async load(cwd = process.cwd()): Promise<void> {
+		this.cwd = cwd;
+		const global = await this.readConfig(this.globalPath());
+		const local = await this.readConfig(this.localPath());
+		const merged = { ...global, ...local };
+		if (!global && !local) markMigrationNoticePending();
+		this.config = this.resolve(merged);
+	}
 
-  getConfig(): ResolvedQuotasConfig {
-    return this.config;
-  }
+	getConfig(): ResolvedQuotasConfig {
+		return this.config;
+	}
 
-  hasConfig(scope: "global" | "local"): boolean {
-    const path = scope === "global" ? this.globalPath() : this.localPath();
-    return existsSync(path);
-  }
+	hasConfig(scope: "global" | "local"): boolean {
+		const path = scope === "global" ? this.globalPath() : this.localPath();
+		return existsSync(path);
+	}
 
-  async save(scope: "global" | "local", config: QuotasConfig): Promise<void> {
-    const path = scope === "global" ? this.globalPath() : this.localPath();
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, JSON.stringify(this.resolve(config), null, 2) + "\n", "utf8");
-    await this.load(this.cwd);
-  }
+	async save(scope: "global" | "local", config: QuotasConfig): Promise<void> {
+		const path = scope === "global" ? this.globalPath() : this.localPath();
+		await mkdir(dirname(path), { recursive: true });
+		await writeFile(
+			path,
+			JSON.stringify(this.resolve(config), null, 2) + "\n",
+			"utf8",
+		);
+		await this.load(this.cwd);
+	}
 }
 
 export const configLoader = new QuotasConfigStore();
 
 export async function seedQuotasConfigIfMissing(): Promise<void> {
-  if (configLoader.hasConfig("global") || configLoader.hasConfig("local")) return;
-  markMigrationNoticePending();
-  try {
-    await configLoader.save("global", DEFAULT_CONFIG);
-  } catch {
-    // ignore
-  }
+	if (configLoader.hasConfig("global") || configLoader.hasConfig("local"))
+		return;
+	markMigrationNoticePending();
+	try {
+		await configLoader.save("global", DEFAULT_CONFIG);
+	} catch {
+		// ignore
+	}
 }
 
 export interface QuotasConfigUpdatedPayload {
-  config: ResolvedQuotasConfig;
+	config: ResolvedQuotasConfig;
 }
 
 export function emitQuotasConfigUpdated(pi: ExtensionAPI): void {
-  pi.events.emit(QUOTAS_CONFIG_UPDATED_EVENT, {
-    config: configLoader.getConfig(),
-  });
+	pi.events.emit(QUOTAS_CONFIG_UPDATED_EVENT, {
+		config: configLoader.getConfig(),
+	});
 }
 
 const FEATURE_META: Array<{
-  id: QuotasFeatureId;
-  label: string;
-  description: string;
+	id: QuotasFeatureId;
+	label: string;
+	description: string;
 }> = [
-  {
-    id: "quotasCommand",
-    label: "Combined quotas command",
-    description: "Toggle the `/quotas` command",
-  },
-  {
-    id: "providerCommands",
-    label: "Provider quota commands",
-    description: "Toggle `/anthropic:quotas`, `/codex:quotas`, `/github:quotas`, `/openrouter:quotas`, and `/synthetic:quotas`",
-  },
-  {
-    id: "usageStatus",
-    label: "Usage status",
-    description: "Toggle footer quota status for the active provider",
-  },
-  {
-    id: "quotaWarnings",
-    label: "Quota warnings",
-    description: "Toggle projected-usage warning notifications",
-  },
-  {
-    id: "deferToSynthetic",
-    label: "Defer to Synthetic",
-    description: "When pi-synthetic is loaded, hide pi-quotas' Synthetic footer to avoid duplicates",
-  },
+	{
+		id: "quotasCommand",
+		label: "Combined quotas command",
+		description: "Toggle the `/quotas` command",
+	},
+	{
+		id: "providerCommands",
+		label: "Provider quota commands",
+		description:
+			"Toggle `/anthropic:quotas`, `/codex:quotas`, `/github:quotas`, `/openrouter:quotas`, and `/synthetic:quotas`",
+	},
+	{
+		id: "usageStatus",
+		label: "Usage status",
+		description: "Toggle footer quota status for the active provider",
+	},
+	{
+		id: "quotaWarnings",
+		label: "Quota warnings",
+		description: "Toggle projected-usage warning notifications",
+	},
+	{
+		id: "deferToSynthetic",
+		label: "Defer to Synthetic",
+		description:
+			"When pi-synthetic is loaded, hide pi-quotas' Synthetic footer to avoid duplicates",
+	},
 ];
 
 export function registerQuotasSettings(
-  pi: ExtensionAPI,
-  getLoadedFeatures: () => Set<QuotasFeatureId>,
+	pi: ExtensionAPI,
+	getLoadedFeatures: () => Set<QuotasFeatureId>,
 ): void {
-  pi.registerCommand("quotas:settings", {
-    description: "Configure quota extension settings",
-    handler: async (_args, ctx) => {
-      await configLoader.load(ctx.cwd);
-      const scopeChoice = await ctx.ui.select("Save settings to", [
-        "global",
-        "local",
-        "cancel",
-      ]);
-      if (!scopeChoice || scopeChoice === "cancel") return;
-      const scope = scopeChoice as "global" | "local";
-      const draft: ResolvedQuotasConfig = { ...configLoader.getConfig() };
+	pi.registerCommand("quotas:settings", {
+		description: "Configure quota extension settings",
+		handler: async (_args, ctx) => {
+			await configLoader.load(ctx.cwd);
+			const scopeChoice = await ctx.ui.select("Save settings to", [
+				"global",
+				"local",
+				"cancel",
+			]);
+			if (!scopeChoice || scopeChoice === "cancel") return;
+			const scope = scopeChoice as "global" | "local";
+			const draft: ResolvedQuotasConfig = { ...configLoader.getConfig() };
 
-      while (true) {
-        const choices = FEATURE_META.map((feature) => {
-          const loaded = getLoadedFeatures().has(feature.id) ? "" : " (not loaded)";
-          const enabled = draft[feature.id] ? "enabled" : "disabled";
-          return `${feature.label}: ${enabled}${loaded}`;
-        });
-        choices.push("Save and exit", "Cancel");
+			while (true) {
+				const choices = FEATURE_META.map((feature) => {
+					const loaded = getLoadedFeatures().has(feature.id)
+						? ""
+						: " (not loaded)";
+					const enabled = draft[feature.id] ? "enabled" : "disabled";
+					return `${feature.label}: ${enabled}${loaded}`;
+				});
+				choices.push("Save and exit", "Cancel");
 
-        const selected = await ctx.ui.select("Quotas Settings", choices);
-        if (!selected || selected === "Cancel") return;
-        if (selected === "Save and exit") {
-          await configLoader.save(scope, draft);
-          emitQuotasConfigUpdated(pi);
-          ctx.ui.notify(
-            "Quota settings saved. Run /reload to fully apply command visibility changes.",
-            "info",
-          );
-          return;
-        }
+				const selected = await ctx.ui.select("Quotas Settings", choices);
+				if (!selected || selected === "Cancel") return;
+				if (selected === "Save and exit") {
+					await configLoader.save(scope, draft);
+					emitQuotasConfigUpdated(pi);
+					ctx.ui.notify(
+						"Quota settings saved. Run /reload to fully apply command visibility changes.",
+						"info",
+					);
+					return;
+				}
 
-        const feature = FEATURE_META.find((item) => selected.startsWith(item.label));
-        if (!feature) continue;
-        if (feature.id !== "deferToSynthetic" && !getLoadedFeatures().has(feature.id)) {
-          ctx.ui.notify(`${feature.label} is not loaded by Pi in this session.`, "warning");
-          continue;
-        }
-        (draft as unknown as Record<string, boolean>)[feature.id] = !(draft as unknown as Record<string, boolean>)[feature.id];
-      }
-    },
-  });
+				const feature = FEATURE_META.find((item) =>
+					selected.startsWith(item.label),
+				);
+				if (!feature) continue;
+				if (
+					feature.id !== "deferToSynthetic" &&
+					!getLoadedFeatures().has(feature.id)
+				) {
+					ctx.ui.notify(
+						`${feature.label} is not loaded by Pi in this session.`,
+						"warning",
+					);
+					continue;
+				}
+				(draft as unknown as Record<string, boolean>)[feature.id] = !(
+					draft as unknown as Record<string, boolean>
+				)[feature.id];
+			}
+		},
+	});
 }

--- a/src/extensions/command-quotas/provider-commands.ts
+++ b/src/extensions/command-quotas/provider-commands.ts
@@ -1,44 +1,50 @@
 import type { SupportedQuotaProvider } from "../../types/quotas.js";
 
 export interface ProviderCommandInfo {
-  provider: SupportedQuotaProvider;
-  commandName: string;
-  title: string;
+	provider: SupportedQuotaProvider;
+	commandName: string;
+	title: string;
 }
 
 export function getProviderCommandInfo(
-  provider: SupportedQuotaProvider,
+	provider: SupportedQuotaProvider,
 ): ProviderCommandInfo {
-  switch (provider) {
-    case "anthropic":
-      return {
-        provider,
-        commandName: "anthropic:quotas",
-        title: "Anthropic Quotas",
-      };
-    case "openai-codex":
-      return {
-        provider,
-        commandName: "codex:quotas",
-        title: "OpenAI Codex Quotas",
-      };
-    case "github-copilot":
-      return {
-        provider,
-        commandName: "github:quotas",
-        title: "GitHub Copilot Quotas",
-      };
-    case "openrouter":
-      return {
-        provider,
-        commandName: "openrouter:quotas",
-        title: "OpenRouter Quotas",
-      };
-    case "synthetic":
-      return {
-        provider,
-        commandName: "synthetic:quotas",
-        title: "Synthetic Quotas",
-      };
-  }
+	switch (provider) {
+		case "anthropic":
+			return {
+				provider,
+				commandName: "anthropic:quotas",
+				title: "Anthropic Quotas",
+			};
+		case "openai-codex":
+			return {
+				provider,
+				commandName: "codex:quotas",
+				title: "OpenAI Codex Quotas",
+			};
+		case "github-copilot":
+			return {
+				provider,
+				commandName: "github:quotas",
+				title: "GitHub Copilot Quotas",
+			};
+		case "openrouter":
+			return {
+				provider,
+				commandName: "openrouter:quotas",
+				title: "OpenRouter Quotas",
+			};
+		case "synthetic":
+			return {
+				provider,
+				commandName: "synthetic:quotas",
+				title: "Synthetic Quotas",
+			};
+		case "opencode-go":
+			return {
+				provider,
+				commandName: "opencode-go:quotas",
+				title: "OpenCode Go Quotas",
+			};
+	}
 }

--- a/src/extensions/command-tokens/command.ts
+++ b/src/extensions/command-tokens/command.ts
@@ -1,0 +1,102 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+} from "@mariozechner/pi-coding-agent";
+import { aggregateAllSessions } from "../../lib/session-tokens.js";
+import { TokensComponent } from "./tokens-display.js";
+
+async function openTokensView(
+	ctx: ExtensionCommandContext,
+	cwd?: string,
+): Promise<void> {
+	const result = await ctx.ui.custom<null>((tui, theme, _kb, done) => {
+		const controller = new AbortController();
+		const component = new TokensComponent(
+			theme,
+			tui,
+			() => {
+				controller.abort();
+				done(null);
+			},
+			() => {
+				component.setState({ type: "loading" });
+				tui.requestRender();
+				void load();
+			},
+			cwd,
+		);
+
+		async function load(): Promise<void> {
+			try {
+				const aggregateResult = await aggregateAllSessions({ cwd });
+				if (controller.signal.aborted) return;
+				component.setState({ type: "loaded", result: aggregateResult });
+				tui.requestRender();
+			} catch (err) {
+				if (controller.signal.aborted) return;
+				component.setState({
+					type: "loaded",
+					result: {
+						totals: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							costTotal: 0,
+						},
+						byModel: [],
+						byProvider: [],
+						bySession: [],
+						sessionCount: 0,
+						messageCount: 0,
+					},
+				});
+				tui.requestRender();
+			}
+		}
+
+		void load();
+
+		return {
+			render: (width: number) => component.render(width),
+			invalidate: () => component.invalidate(),
+			handleInput: (data: string) => component.handleInput(data),
+			dispose: () => {
+				controller.abort();
+				component.destroy();
+			},
+		};
+	});
+
+	// Fallback for non-interactive mode
+	if (result === undefined) {
+		const aggregateResult = await aggregateAllSessions({ cwd });
+		const { totals } = aggregateResult;
+		const lines = [
+			`Token Usage: ${aggregateResult.sessionCount} sessions, ${aggregateResult.messageCount} messages`,
+			`  Input: ${totals.input.toLocaleString()} · Output: ${totals.output.toLocaleString()}`,
+			`  Cache Read: ${totals.cacheRead.toLocaleString()} · Cache Write: ${totals.cacheWrite.toLocaleString()}`,
+			`  Total: ${totals.totalTokens.toLocaleString()} tokens · $${totals.costTotal.toFixed(2)}`,
+		];
+		for (const model of aggregateResult.byModel) {
+			lines.push(
+				`  ${model.provider}/${model.model}: $${model.tokens.costTotal.toFixed(2)} (${model.messageCount} msgs)`,
+			);
+		}
+		ctx.ui.notify(lines.join("\n"), "info");
+	}
+}
+
+export function registerTokensCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("tokens", {
+		description: "Display token usage and cost across all sessions",
+		handler: async (_args, ctx) => {
+			await openTokensView(ctx, ctx.cwd);
+		},
+	});
+}
+
+export default async function (pi: ExtensionAPI) {
+	registerTokensCommand(pi);
+}

--- a/src/extensions/command-tokens/index.ts
+++ b/src/extensions/command-tokens/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./command.js";

--- a/src/extensions/command-tokens/tokens-display.ts
+++ b/src/extensions/command-tokens/tokens-display.ts
@@ -1,0 +1,359 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+import { Loader, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
+import pkg from "../../../package.json" with { type: "json" };
+import type {
+	AggregateResult,
+	TokenBuckets,
+} from "../../lib/session-tokens.js";
+import {
+	aggregateAllSessions,
+	formatCost,
+	formatNumber,
+	formatTokenSummary,
+} from "../../lib/session-tokens.js";
+
+type TokensState =
+	| { type: "loading" }
+	| { type: "loaded"; result: AggregateResult };
+
+type TabId = "overview" | "models" | "sessions";
+
+const TABS: Array<{ id: TabId; label: string }> = [
+	{ id: "overview", label: "Overview" },
+	{ id: "models", label: "Models" },
+	{ id: "sessions", label: "Sessions" },
+];
+
+function renderProgressBar(
+	value: number,
+	max: number,
+	width: number,
+	theme: Theme,
+): string {
+	if (max <= 0 || value <= 0) return theme.fg("dim", "░".repeat(width));
+	const ratio = Math.min(1, value / max);
+	const filled = Math.round(ratio * width);
+	const parts: string[] = [];
+	for (let i = 0; i < width; i++) {
+		parts.push(i < filled ? theme.fg("accent", "█") : theme.fg("dim", "░"));
+	}
+	return parts.join("");
+}
+
+export class TokensComponent implements Component {
+	private state: TokensState = { type: "loading" };
+	private loader: Loader | null = null;
+	private activeTab: TabId = "overview";
+	private scrollOffset = 0;
+
+	constructor(
+		private theme: Theme,
+		private tui: any,
+		private onClose: () => void,
+		private onRefetch: () => void,
+		private cwd?: string,
+	) {
+		this.startLoader();
+	}
+
+	private startLoader(): void {
+		this.loader = new Loader(
+			this.tui,
+			(s: string) => this.theme.fg("accent", s),
+			(s: string) => this.theme.fg("muted", s),
+			"Scanning sessions...",
+		);
+	}
+
+	destroy(): void {
+		this.loader?.stop();
+		this.loader = null;
+	}
+
+	setState(state: TokensState): void {
+		if (state.type === "loading") {
+			this.loader?.stop();
+			this.startLoader();
+			this.scrollOffset = 0;
+		} else if (this.state.type === "loading") {
+			this.loader?.stop();
+			this.loader = null;
+		}
+		this.state = state;
+	}
+
+	handleInput(data: string): boolean {
+		if (matchesKey(data, "escape") || data === "q") {
+			this.onClose();
+			return true;
+		}
+		if (data === "r") {
+			this.onRefetch();
+			return true;
+		}
+		if (data === "\t" || data === "right") {
+			const idx = TABS.findIndex((t) => t.id === this.activeTab);
+			this.activeTab = TABS[(idx + 1) % TABS.length].id;
+			this.scrollOffset = 0;
+			this.tui.requestRender();
+			return true;
+		}
+		if (data === "left") {
+			const idx = TABS.findIndex((t) => t.id === this.activeTab);
+			this.activeTab = TABS[(idx - 1 + TABS.length) % TABS.length].id;
+			this.scrollOffset = 0;
+			this.tui.requestRender();
+			return true;
+		}
+		if (data === "1") {
+			this.activeTab = "overview";
+			this.scrollOffset = 0;
+			this.tui.requestRender();
+			return true;
+		}
+		if (data === "2") {
+			this.activeTab = "models";
+			this.scrollOffset = 0;
+			this.tui.requestRender();
+			return true;
+		}
+		if (data === "3") {
+			this.activeTab = "sessions";
+			this.scrollOffset = 0;
+			this.tui.requestRender();
+			return true;
+		}
+		if (matchesKey(data, "down") || data === "j") {
+			this.scrollOffset++;
+			this.tui.requestRender();
+			return true;
+		}
+		if (matchesKey(data, "up") || data === "k") {
+			this.scrollOffset = Math.max(0, this.scrollOffset - 1);
+			this.tui.requestRender();
+			return true;
+		}
+		return false;
+	}
+
+	render(width: number): string[] {
+		const lines: string[] = [];
+		const border = new DynamicBorder((s: string) => this.theme.fg("border", s));
+		lines.push(...border.render(width));
+		lines.push(
+			truncateToWidth(
+				` ${this.theme.fg("accent", this.theme.bold("Token Usage"))}`,
+				width,
+			),
+		);
+
+		// Tab bar
+		const tabParts = TABS.map((tab) => {
+			if (tab.id === this.activeTab) {
+				return this.theme.fg("accent", this.theme.bold(`[${tab.label}]`));
+			}
+			return this.theme.fg("dim", ` ${tab.label} `);
+		});
+		lines.push(truncateToWidth(`  ${tabParts.join("  ")}`, width));
+		lines.push("");
+
+		if (this.state.type === "loading") {
+			lines.push(
+				...(this.loader
+					? this.loader.render(width)
+					: [this.theme.fg("muted", "  Scanning sessions...")]),
+			);
+		} else {
+			const contentLines = this.renderTab(width);
+			// Apply scroll
+			const maxVisible = Math.max(1, 20); // approximate visible lines
+			const visible = contentLines.slice(
+				this.scrollOffset,
+				this.scrollOffset + maxVisible,
+			);
+			lines.push(...visible);
+		}
+
+		lines.push("");
+		lines.push(
+			this.theme.fg(
+				"dim",
+				`  pi-quotas v${pkg.version}  ·  1/2/3 switch tab  r refresh  q/Esc close`,
+			),
+		);
+		lines.push(...border.render(width));
+		return lines;
+	}
+
+	private renderTab(width: number): string[] {
+		if (this.state.type !== "loaded") return [];
+		const { result } = this.state;
+
+		switch (this.activeTab) {
+			case "overview":
+				return this.renderOverview(result, width);
+			case "models":
+				return this.renderModels(result, width);
+			case "sessions":
+				return this.renderSessions(result, width);
+		}
+	}
+
+	private renderOverview(result: AggregateResult, width: number): string[] {
+		const lines: string[] = [];
+		const { totals } = result;
+
+		lines.push(
+			truncateToWidth(
+				`  ${this.theme.fg("accent", this.theme.bold("Summary"))}`,
+				width,
+			),
+		);
+		lines.push("");
+
+		const statRows = [
+			["Sessions", String(result.sessionCount)],
+			["Messages", String(result.messageCount)],
+			["Input tokens", formatNumber(totals.input)],
+			["Output tokens", formatNumber(totals.output)],
+			["Cache read", formatNumber(totals.cacheRead)],
+			["Cache write", formatNumber(totals.cacheWrite)],
+			["Total tokens", formatNumber(totals.totalTokens)],
+			["Total cost", formatCost(totals.costTotal)],
+		];
+
+		const labelWidth = Math.max(...statRows.map(([l]) => l.length));
+		for (const [label, value] of statRows) {
+			lines.push(
+				truncateToWidth(
+					`  ${this.theme.fg("dim", label.padEnd(labelWidth))}  ${this.theme.fg("accent", value)}`,
+					width,
+				),
+			);
+		}
+
+		// Provider breakdown
+		if (result.byProvider.length > 0) {
+			lines.push("");
+			lines.push(
+				truncateToWidth(
+					`  ${this.theme.fg("accent", this.theme.bold("By Provider"))}`,
+					width,
+				),
+			);
+			lines.push("");
+			const maxCost = Math.max(
+				...result.byProvider.map((p) => p.tokens.costTotal),
+			);
+			for (const provider of result.byProvider) {
+				const barWidth = Math.min(20, Math.max(8, width - 40));
+				const bar = renderProgressBar(
+					provider.tokens.costTotal,
+					maxCost,
+					barWidth,
+					this.theme,
+				);
+				const cost = formatCost(provider.tokens.costTotal);
+				const msgs = `${provider.messageCount} msgs`;
+				lines.push(
+					truncateToWidth(
+						`  ${this.theme.fg("accent", provider.provider.padEnd(20))} ${bar} ${this.theme.fg("accent", cost)} ${this.theme.fg("dim", msgs)}`,
+						width,
+					),
+				);
+			}
+		}
+
+		return lines;
+	}
+
+	private renderModels(result: AggregateResult, width: number): string[] {
+		const lines: string[] = [];
+
+		if (result.byModel.length === 0) {
+			lines.push(this.theme.fg("dim", "  No assistant messages found"));
+			return lines;
+		}
+
+		const maxCost = Math.max(...result.byModel.map((m) => m.tokens.costTotal));
+
+		for (const model of result.byModel) {
+			const barWidth = Math.min(16, Math.max(8, width - 50));
+			const bar = renderProgressBar(
+				model.tokens.costTotal,
+				maxCost,
+				barWidth,
+				this.theme,
+			);
+			const cost = formatCost(model.tokens.costTotal);
+			const label =
+				model.provider === model.model
+					? model.model
+					: `${model.provider}/${model.model}`;
+			const shortLabel = label.length > 30 ? label.slice(0, 27) + "..." : label;
+
+			lines.push(
+				truncateToWidth(`  ${this.theme.fg("accent", shortLabel)}`, width),
+			);
+			lines.push(
+				truncateToWidth(
+					`    ${bar} ${this.theme.fg("accent", cost)}  ${this.theme.fg("dim", formatTokenSummary(model.tokens))}`,
+					width,
+				),
+			);
+		}
+
+		return lines;
+	}
+
+	private renderSessions(result: AggregateResult, width: number): string[] {
+		const lines: string[] = [];
+
+		if (result.bySession.length === 0) {
+			lines.push(this.theme.fg("dim", "  No sessions found"));
+			return lines;
+		}
+
+		const maxCost = Math.max(
+			...result.bySession.map((s) => s.tokens.costTotal),
+		);
+
+		for (const session of result.bySession) {
+			const dateStr = session.created.toISOString().slice(0, 10);
+			const name = session.name ?? session.sessionId.slice(0, 8);
+			const cost = formatCost(session.tokens.costTotal);
+			const msgs = `${session.messageCount} msgs`;
+
+			const barWidth = Math.min(12, Math.max(6, width - 50));
+			const bar = renderProgressBar(
+				session.tokens.costTotal,
+				maxCost,
+				barWidth,
+				this.theme,
+			);
+
+			lines.push(
+				truncateToWidth(
+					`  ${this.theme.fg("dim", dateStr)} ${this.theme.fg("accent", name)} ${bar} ${this.theme.fg("accent", cost)} ${this.theme.fg("dim", msgs)}`,
+					width,
+				),
+			);
+		}
+
+		if (result.sessionCount > result.bySession.length) {
+			lines.push("");
+			lines.push(
+				this.theme.fg(
+					"dim",
+					`  Showing ${result.bySession.length} of ${result.sessionCount} sessions`,
+				),
+			);
+		}
+
+		return lines;
+	}
+
+	invalidate(): void {}
+}

--- a/src/extensions/quota-warnings/index.ts
+++ b/src/extensions/quota-warnings/index.ts
@@ -1,16 +1,23 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
 import {
-  QUOTAS_CONFIG_UPDATED_EVENT,
-  QUOTAS_EXTENSIONS_REGISTER_EVENT,
-  QUOTAS_EXTENSIONS_REQUEST_EVENT,
-  type QuotasConfigUpdatedPayload,
-  configLoader,
+	QUOTAS_CONFIG_UPDATED_EVENT,
+	QUOTAS_EXTENSIONS_REGISTER_EVENT,
+	QUOTAS_EXTENSIONS_REQUEST_EVENT,
+	type QuotasConfigUpdatedPayload,
+	configLoader,
 } from "../../config.js";
-import { fetchProviderQuotas, isSupportedProvider } from "../../lib/quotas.js";
 import {
-  assessWindow,
-  formatTimeRemaining,
-  type RiskSeverity,
+	fetchProviderQuotas,
+	isSupportedProvider,
+	PROVIDER_LABELS,
+} from "../../lib/quotas.js";
+import {
+	assessWindow,
+	formatTimeRemaining,
+	type RiskSeverity,
 } from "../../utils/quotas-severity.js";
 
 const COOLDOWN_MS = 60 * 60 * 1000;
@@ -21,114 +28,129 @@ const alertState = new Map<string, AlertState>();
 let lastFetchAt = 0;
 
 function shouldNotify(key: string, severity: RiskSeverity): boolean {
-  const current = alertState.get(key);
-  if (!current) return true;
-  const order: RiskSeverity[] = ["none", "warning", "high", "critical"];
-  if (order.indexOf(severity) > order.indexOf(current.lastSeverity)) return true;
-  if (severity === "high" || severity === "critical") return true;
-  if (severity === "warning") return Date.now() - current.lastNotifiedAt >= COOLDOWN_MS;
-  return false;
+	const current = alertState.get(key);
+	if (!current) return true;
+	const order: RiskSeverity[] = ["none", "warning", "high", "critical"];
+	if (order.indexOf(severity) > order.indexOf(current.lastSeverity))
+		return true;
+	if (severity === "high" || severity === "critical") return true;
+	if (severity === "warning")
+		return Date.now() - current.lastNotifiedAt >= COOLDOWN_MS;
+	return false;
 }
 
 function markNotified(key: string, severity: RiskSeverity): void {
-  alertState.set(key, { lastSeverity: severity, lastNotifiedAt: Date.now() });
+	alertState.set(key, { lastSeverity: severity, lastNotifiedAt: Date.now() });
 }
 
 function clearAlertState(): void {
-  alertState.clear();
-  lastFetchAt = 0;
+	alertState.clear();
+	lastFetchAt = 0;
 }
 
 export default async function (pi: ExtensionAPI) {
-  await configLoader.load();
-  let enabled = configLoader.getConfig().quotaWarnings;
-  let currentContext: ExtensionContext | undefined;
-  async function check(ctx: ExtensionContext, onlyNew: boolean): Promise<void> {
-    const provider = ctx.model?.provider;
-    if (!ctx.hasUI || !provider || !isSupportedProvider(provider)) return;
-    const now = Date.now();
-    if (onlyNew && now - lastFetchAt < MIN_FETCH_INTERVAL_MS) return;
-    lastFetchAt = now;
+	await configLoader.load();
+	let enabled = configLoader.getConfig().quotaWarnings;
+	let currentContext: ExtensionContext | undefined;
+	async function check(ctx: ExtensionContext, onlyNew: boolean): Promise<void> {
+		const provider = ctx.model?.provider;
+		if (!ctx.hasUI || !provider || !isSupportedProvider(provider)) return;
+		const now = Date.now();
+		if (onlyNew && now - lastFetchAt < MIN_FETCH_INTERVAL_MS) return;
+		lastFetchAt = now;
 
-    const result = await fetchProviderQuotas(ctx.modelRegistry.authStorage, provider);
-    if (!result.success) return;
+		const result = await fetchProviderQuotas(
+			ctx.modelRegistry.authStorage,
+			provider,
+		);
+		if (!result.success) return;
 
-    const risky = result.data.windows
-      .map((window) => ({ window, assessment: assessWindow(window) }))
-      .filter((entry) => entry.assessment.severity !== "none");
-    if (risky.length === 0) return;
+		const risky = result.data.windows
+			.map((window) => ({ window, assessment: assessWindow(window) }))
+			.filter((entry) => entry.assessment.severity !== "none");
+		if (risky.length === 0) return;
 
-    const toNotify = onlyNew
-      ? risky.filter((entry) => shouldNotify(`${provider}:${entry.window.label}`, entry.assessment.severity))
-      : risky;
-    if (toNotify.length === 0) return;
+		const toNotify = onlyNew
+			? risky.filter((entry) =>
+					shouldNotify(
+						`${provider}:${entry.window.label}`,
+						entry.assessment.severity,
+					),
+				)
+			: risky;
+		if (toNotify.length === 0) return;
 
-    for (const entry of toNotify) {
-      markNotified(`${provider}:${entry.window.label}`, entry.assessment.severity);
-    }
+		for (const entry of toNotify) {
+			markNotified(
+				`${provider}:${entry.window.label}`,
+				entry.assessment.severity,
+			);
+		}
 
-    const providerName = provider === "openai-codex"
-      ? "Codex"
-      : provider === "github-copilot"
-        ? "GitHub Copilot"
-        : "Anthropic";
+		const providerName = PROVIDER_LABELS[provider];
 
-    const lines = toNotify.map(({ window, assessment }) => {
-      const projected = Math.round(assessment.projectedPercent);
-      const used = Math.round(window.usedPercent);
-      return `- ${window.label}: ${used}% used, projected ${projected}% (${assessment.severity}), resets in ${formatTimeRemaining(window.resetsAt)}`;
-    });
+		const lines = toNotify.map(({ window, assessment }) => {
+			const projected = Math.round(assessment.projectedPercent);
+			const used = Math.round(window.usedPercent);
+			return `- ${window.label}: ${used}% used, projected ${projected}% (${assessment.severity}), resets in ${formatTimeRemaining(window.resetsAt)}`;
+		});
 
-    const level = toNotify.some((entry) => entry.assessment.severity === "critical" || entry.assessment.severity === "high")
-      ? "error"
-      : "warning";
-    ctx.ui.notify(`${providerName} quota warning:\n${lines.join("\n")}`, level);
-  }
+		const level = toNotify.some(
+			(entry) =>
+				entry.assessment.severity === "critical" ||
+				entry.assessment.severity === "high",
+		)
+			? "error"
+			: "warning";
+		ctx.ui.notify(`${providerName} quota warning:\n${lines.join("\n")}`, level);
+	}
 
-  function scheduleCheck(ctx: ExtensionContext, onlyNew: boolean): void {
-    void check(ctx, onlyNew).catch(() => {
-      // Quota warnings are opportunistic; never let a failed quota check block Pi events.
-    });
-  }
+	function scheduleCheck(ctx: ExtensionContext, onlyNew: boolean): void {
+		void check(ctx, onlyNew).catch(() => {
+			// Quota warnings are opportunistic; never let a failed quota check block Pi events.
+		});
+	}
 
-  pi.events.on(QUOTAS_CONFIG_UPDATED_EVENT, (data: unknown) => {
-    enabled = (data as QuotasConfigUpdatedPayload).config.quotaWarnings;
-    if (!enabled) {
-      clearAlertState();
-      return;
-    }
-    if (currentContext) {
-      clearAlertState();
-      scheduleCheck(currentContext, false);
-    }
-  });
+	pi.events.on(QUOTAS_CONFIG_UPDATED_EVENT, (data: unknown) => {
+		enabled = (data as QuotasConfigUpdatedPayload).config.quotaWarnings;
+		if (!enabled) {
+			clearAlertState();
+			return;
+		}
+		if (currentContext) {
+			clearAlertState();
+			scheduleCheck(currentContext, false);
+		}
+	});
 
-  pi.on("session_start", (_event, ctx) => {
-    currentContext = ctx;
-    clearAlertState();
-    if (!enabled) return;
-    scheduleCheck(ctx, false);
-  });
+	pi.on("session_start", (_event, ctx) => {
+		currentContext = ctx;
+		clearAlertState();
+		if (!enabled) return;
+		scheduleCheck(ctx, false);
+	});
 
-  pi.on("turn_end", (_event, ctx) => {
-    currentContext = ctx;
-    if (!enabled) return;
-    scheduleCheck(ctx, true);
-  });
+	pi.on("turn_end", (_event, ctx) => {
+		currentContext = ctx;
+		if (!enabled) return;
+		scheduleCheck(ctx, true);
+	});
 
-  pi.on("model_select", async (_event, ctx) => {
-    currentContext = ctx;
-    clearAlertState();
-  });
+	pi.on("model_select", async (_event, ctx) => {
+		currentContext = ctx;
+		clearAlertState();
+	});
 
-  pi.on("session_shutdown", async () => {
-    currentContext = undefined;
-    clearAlertState();
-  });
+	pi.on("session_shutdown", async () => {
+		currentContext = undefined;
+		clearAlertState();
+	});
 
-  pi.events.on(QUOTAS_EXTENSIONS_REQUEST_EVENT, () => {
-    if (configLoader.getConfig().quotaWarnings) {
-      pi.events.emit(QUOTAS_EXTENSIONS_REGISTER_EVENT, { feature: "quotaWarnings" });
-    }
-  });
+	pi.events.on(QUOTAS_EXTENSIONS_REQUEST_EVENT, () => {
+		if (configLoader.getConfig().quotaWarnings) {
+			pi.events.emit(QUOTAS_EXTENSIONS_REGISTER_EVENT, {
+				feature: "quotaWarnings",
+			});
+		}
+	});
 }

--- a/src/extensions/token-status/index.ts
+++ b/src/extensions/token-status/index.ts
@@ -1,0 +1,240 @@
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
+import {
+	QUOTAS_CONFIG_UPDATED_EVENT,
+	QUOTAS_EXTENSIONS_REGISTER_EVENT,
+	QUOTAS_EXTENSIONS_REQUEST_EVENT,
+	type QuotasConfigUpdatedPayload,
+	configLoader,
+} from "../../config.js";
+import { aggregateAllSessions, formatCost } from "../../lib/session-tokens.js";
+
+const EXTENSION_ID = "pi-quotas-token-status";
+const REFRESH_INTERVAL_MS = 60_000;
+
+/** Go tier limits (approximate, from docs) */
+const GO_LIMITS = {
+	rolling5h: 12, // $12 per 5 hours
+	weekly: 30, // $30 per week
+	monthly: 60, // $60 per month
+} as const;
+
+interface RollingWindowCosts {
+	rolling5h: number;
+	weekly: number;
+	monthly: number;
+}
+
+function computeWindowTimestamps(now: Date): {
+	since5h: Date;
+	sinceWeekly: Date;
+	sinceMonthly: Date;
+} {
+	return {
+		since5h: new Date(now.getTime() - 5 * 60 * 60 * 1000),
+		sinceWeekly: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
+		sinceMonthly: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+	};
+}
+
+async function computeRollingCosts(cwd?: string): Promise<RollingWindowCosts> {
+	const now = new Date();
+	const { since5h, sinceWeekly, sinceMonthly } = computeWindowTimestamps(now);
+
+	// Run all three aggregations in parallel
+	const [result5h, resultWeekly, resultMonthly] = await Promise.all([
+		aggregateAllSessions({ cwd, since: since5h }),
+		aggregateAllSessions({ cwd, since: sinceWeekly }),
+		aggregateAllSessions({ cwd, since: sinceMonthly }),
+	]);
+
+	return {
+		rolling5h: result5h.totals.costTotal,
+		weekly: resultWeekly.totals.costTotal,
+		monthly: resultMonthly.totals.costTotal,
+	};
+}
+
+function formatWindowForStatus(
+	theme: ExtensionContext["ui"]["theme"],
+	label: string,
+	cost: number,
+	limit: number,
+): string {
+	const percent = limit > 0 ? Math.round((cost / limit) * 100) : 0;
+	const costStr = formatCost(cost);
+
+	// Color by usage level
+	let color: string;
+	if (percent >= 90) {
+		color = "error";
+	} else if (percent >= 70) {
+		color = "warning";
+	} else {
+		color = "dim";
+	}
+
+	return `${theme.fg(color, `${label}:`)}${theme.fg("accent", costStr)}`;
+}
+
+function formatTokenStatus(
+	theme: ExtensionContext["ui"]["theme"],
+	costs: RollingWindowCosts,
+): string {
+	const parts = [
+		formatWindowForStatus(theme, "5h", costs.rolling5h, GO_LIMITS.rolling5h),
+		formatWindowForStatus(theme, "wk", costs.weekly, GO_LIMITS.weekly),
+		formatWindowForStatus(theme, "mo", costs.monthly, GO_LIMITS.monthly),
+	];
+	return parts.join(" · ");
+}
+
+function isGoProvider(provider: string | undefined): boolean {
+	if (!provider) return false;
+	return provider === "opencode-go" || provider.startsWith("opencode-go/");
+}
+
+function createTokenStatusRefresher() {
+	let refreshTimer: ReturnType<typeof setInterval> | undefined;
+	let activeContext: ExtensionContext | undefined;
+	let lastCosts: RollingWindowCosts | undefined;
+	let inFlight = false;
+	let queued = false;
+
+	async function update(ctx: ExtensionContext): Promise<void> {
+		if (!ctx.hasUI) return;
+		if (inFlight) {
+			queued = true;
+			return;
+		}
+		inFlight = true;
+		try {
+			const costs = await computeRollingCosts(ctx.cwd);
+			if (!ctx.hasUI) return;
+			lastCosts = costs;
+			const status = formatTokenStatus(ctx.ui.theme, costs);
+			ctx.ui.setStatus(EXTENSION_ID, status);
+		} catch {
+			ctx.ui.setStatus(
+				EXTENSION_ID,
+				ctx.ui.theme.fg("warning", "token tracking unavailable"),
+			);
+		} finally {
+			inFlight = false;
+			if (queued) {
+				queued = false;
+				void update(ctx);
+			}
+		}
+	}
+
+	return {
+		async refreshFor(ctx: ExtensionContext): Promise<void> {
+			activeContext = ctx;
+			if (!isGoProvider(ctx.model?.provider)) {
+				ctx.ui.setStatus(EXTENSION_ID, undefined);
+				return;
+			}
+			await update(ctx);
+		},
+		start(): void {
+			if (refreshTimer) clearInterval(refreshTimer);
+			refreshTimer = setInterval(() => {
+				if (activeContext) void update(activeContext);
+			}, REFRESH_INTERVAL_MS);
+			refreshTimer.unref?.();
+		},
+		stop(ctx?: ExtensionContext): void {
+			if (refreshTimer) clearInterval(refreshTimer);
+			refreshTimer = undefined;
+			activeContext = undefined;
+			lastCosts = undefined;
+			ctx?.ui.setStatus(EXTENSION_ID, undefined);
+		},
+		renderLast(ctx: ExtensionContext): boolean {
+			if (!lastCosts || !ctx.hasUI) return false;
+			ctx.ui.setStatus(
+				EXTENSION_ID,
+				formatTokenStatus(ctx.ui.theme, lastCosts),
+			);
+			return true;
+		},
+	};
+}
+
+export default async function (pi: ExtensionAPI) {
+	await configLoader.load();
+	const refresher = createTokenStatusRefresher();
+	let enabled = configLoader.getConfig().tokenStatus;
+	let currentContext: ExtensionContext | undefined;
+
+	function scheduleRefresh(ctx: ExtensionContext): void {
+		void refresher.refreshFor(ctx).catch(() => {
+			if (ctx.hasUI)
+				ctx.ui.setStatus(
+					EXTENSION_ID,
+					ctx.ui.theme.fg("warning", "token tracking unavailable"),
+				);
+		});
+	}
+
+	pi.events.on(QUOTAS_CONFIG_UPDATED_EVENT, (data: unknown) => {
+		const config = (data as QuotasConfigUpdatedPayload).config;
+		enabled = config.tokenStatus;
+		if (!enabled) {
+			refresher.stop(currentContext);
+			return;
+		}
+		if (currentContext) {
+			refresher.start();
+			scheduleRefresh(currentContext);
+		}
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		currentContext = ctx;
+		if (!enabled) return;
+		if (!isGoProvider(ctx.model?.provider)) {
+			ctx.ui.setStatus(EXTENSION_ID, undefined);
+			return;
+		}
+		refresher.start();
+		scheduleRefresh(ctx);
+	});
+
+	pi.on("turn_end", (_event, ctx) => {
+		currentContext = ctx;
+		if (!enabled) return;
+		if (!isGoProvider(ctx.model?.provider)) return;
+		scheduleRefresh(ctx);
+	});
+
+	pi.on("model_select", (_event, ctx) => {
+		currentContext = ctx;
+		if (!enabled) {
+			refresher.stop(ctx);
+			return;
+		}
+		if (!isGoProvider(ctx.model?.provider)) {
+			refresher.stop(ctx);
+			return;
+		}
+		refresher.start();
+		scheduleRefresh(ctx);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		currentContext = undefined;
+		refresher.stop(ctx);
+	});
+
+	pi.events.on(QUOTAS_EXTENSIONS_REQUEST_EVENT, () => {
+		if (configLoader.getConfig().tokenStatus) {
+			pi.events.emit(QUOTAS_EXTENSIONS_REGISTER_EVENT, {
+				feature: "tokenStatus",
+			});
+		}
+	});
+}

--- a/src/extensions/token-status/provider-detection.test.ts
+++ b/src/extensions/token-status/provider-detection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+// Extract isGoProvider logic for testing
+function isGoProvider(provider: string | undefined): boolean {
+	if (!provider) return false;
+	return provider === "opencode-go" || provider.startsWith("opencode-go/");
+}
+
+describe("isGoProvider", () => {
+	it("detects opencode-go provider", () => {
+		expect(isGoProvider("opencode-go")).toBe(true);
+	});
+
+	it("detects opencode-go/ prefixed providers", () => {
+		expect(isGoProvider("opencode-go/anthropic")).toBe(true);
+		expect(isGoProvider("opencode-go/openai")).toBe(true);
+	});
+
+	it("rejects non-go providers", () => {
+		expect(isGoProvider("opencode")).toBe(false);
+		expect(isGoProvider("anthropic")).toBe(false);
+		expect(isGoProvider("openai")).toBe(false);
+		expect(isGoProvider("github-copilot")).toBe(false);
+	});
+
+	it("rejects undefined/empty", () => {
+		expect(isGoProvider(undefined)).toBe(false);
+		expect(isGoProvider("")).toBe(false);
+	});
+});

--- a/src/lib/quotas.ts
+++ b/src/lib/quotas.ts
@@ -3,100 +3,108 @@ import { PROVIDER_FETCHERS } from "../providers/fetch.js";
 import type { QuotasResult, SupportedQuotaProvider } from "../types/quotas.js";
 
 export const SUPPORTED_PROVIDERS: SupportedQuotaProvider[] = [
-  "anthropic",
-  "openai-codex",
-  "github-copilot",
-  "openrouter",
-  "synthetic",
+	"anthropic",
+	"openai-codex",
+	"github-copilot",
+	"openrouter",
+	"synthetic",
+	"opencode-go",
 ];
 
 export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
-  anthropic: "Anthropic",
-  "openai-codex": "OpenAI Codex",
-  "github-copilot": "GitHub Copilot",
-  openrouter: "OpenRouter",
-  synthetic: "Synthetic",
+	anthropic: "Anthropic",
+	"openai-codex": "OpenAI Codex",
+	"github-copilot": "GitHub Copilot",
+	openrouter: "OpenRouter",
+	synthetic: "Synthetic",
+	"opencode-go": "OpenCode Go",
 };
 
 const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
-  anthropic: 5 * 60_000,
-  "openai-codex": 60_000,
-  "github-copilot": 5 * 60_000,
-  openrouter: 60_000,
-  synthetic: 60_000,
+	anthropic: 5 * 60_000,
+	"openai-codex": 60_000,
+	"github-copilot": 5 * 60_000,
+	openrouter: 60_000,
+	synthetic: 60_000,
+	"opencode-go": 60_000,
 };
 
 type CacheEntry = {
-  result?: QuotasResult;
-  fetchedAt?: number;
-  inFlight?: Promise<QuotasResult>;
+	result?: QuotasResult;
+	fetchedAt?: number;
+	inFlight?: Promise<QuotasResult>;
 };
 
 const cache = new Map<SupportedQuotaProvider, CacheEntry>();
 
 export function isSupportedProvider(
-  provider: string | undefined,
+	provider: string | undefined,
 ): provider is SupportedQuotaProvider {
-  return SUPPORTED_PROVIDERS.includes(provider as SupportedQuotaProvider);
+	return SUPPORTED_PROVIDERS.includes(provider as SupportedQuotaProvider);
 }
 
 export function clearQuotaCache(provider?: SupportedQuotaProvider): void {
-  if (provider) cache.delete(provider);
-  else cache.clear();
+	if (provider) cache.delete(provider);
+	else cache.clear();
 }
 
 export async function fetchProviderQuotas(
-  authStorage: AuthStorage,
-  provider: SupportedQuotaProvider,
-  options?: { force?: boolean; signal?: AbortSignal },
+	authStorage: AuthStorage,
+	provider: SupportedQuotaProvider,
+	options?: { force?: boolean; signal?: AbortSignal },
 ): Promise<QuotasResult> {
-  const entry = cache.get(provider) ?? {};
-  const now = Date.now();
-  const ttl = PROVIDER_TTLS_MS[provider];
+	const entry = cache.get(provider) ?? {};
+	const now = Date.now();
+	const ttl = PROVIDER_TTLS_MS[provider];
 
-  if (!options?.force && entry.result && entry.fetchedAt && now - entry.fetchedAt < ttl) {
-    return entry.result;
-  }
-  if (!options?.force && entry.inFlight) return entry.inFlight;
+	if (
+		!options?.force &&
+		entry.result &&
+		entry.fetchedAt &&
+		now - entry.fetchedAt < ttl
+	) {
+		return entry.result;
+	}
+	if (!options?.force && entry.inFlight) return entry.inFlight;
 
-  const promise = PROVIDER_FETCHERS[provider](authStorage, options?.signal)
-    .then((result: QuotasResult) => {
-      cache.set(provider, { result, fetchedAt: Date.now() });
-      return result;
-    })
-    .finally(() => {
-      const current = cache.get(provider) ?? {};
-      delete current.inFlight;
-      cache.set(provider, current);
-    });
+	const promise = PROVIDER_FETCHERS[provider](authStorage, options?.signal)
+		.then((result: QuotasResult) => {
+			cache.set(provider, { result, fetchedAt: Date.now() });
+			return result;
+		})
+		.finally(() => {
+			const current = cache.get(provider) ?? {};
+			delete current.inFlight;
+			cache.set(provider, current);
+		});
 
-  cache.set(provider, { ...entry, inFlight: promise });
-  return promise;
+	cache.set(provider, { ...entry, inFlight: promise });
+	return promise;
 }
 
 export async function fetchAllProviderQuotas(
-  authStorage: AuthStorage,
-  options?: { force?: boolean; signal?: AbortSignal },
+	authStorage: AuthStorage,
+	options?: { force?: boolean; signal?: AbortSignal },
 ): Promise<Array<{ provider: SupportedQuotaProvider; result: QuotasResult }>> {
-  return Promise.all(
-    SUPPORTED_PROVIDERS.map(async (provider) => ({
-      provider,
-      result: await fetchProviderQuotas(authStorage, provider, options),
-    })),
-  );
+	return Promise.all(
+		SUPPORTED_PROVIDERS.map(async (provider) => ({
+			provider,
+			result: await fetchProviderQuotas(authStorage, provider, options),
+		})),
+	);
 }
 
 export function formatResetTime(renewsAt: string): string {
-  const date = new Date(renewsAt);
-  const now = new Date();
-  const diffMs = date.getTime() - now.getTime();
+	const date = new Date(renewsAt);
+	const now = new Date();
+	const diffMs = date.getTime() - now.getTime();
 
-  if (diffMs <= 0) return "soon";
+	if (diffMs <= 0) return "soon";
 
-  const diffHours = Math.ceil(diffMs / (1000 * 60 * 60));
-  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+	const diffHours = Math.ceil(diffMs / (1000 * 60 * 60));
+	const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
 
-  if (diffHours < 24) return `in ${diffHours}h`;
-  if (diffDays < 7) return `in ${diffDays}d`;
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+	if (diffHours < 24) return `in ${diffHours}h`;
+	if (diffDays < 7) return `in ${diffDays}d`;
+	return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }

--- a/src/lib/session-tokens.test.ts
+++ b/src/lib/session-tokens.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+	addBuckets,
+	emptyBuckets,
+	formatCost,
+	formatNumber,
+	formatTokenSummary,
+	type TokenBuckets,
+} from "./session-tokens.js";
+
+describe("emptyBuckets", () => {
+	it("returns all zeros", () => {
+		const b = emptyBuckets();
+		expect(b.input).toBe(0);
+		expect(b.output).toBe(0);
+		expect(b.cacheRead).toBe(0);
+		expect(b.cacheWrite).toBe(0);
+		expect(b.totalTokens).toBe(0);
+		expect(b.costTotal).toBe(0);
+	});
+});
+
+describe("addBuckets", () => {
+	it("sums two bucket sets", () => {
+		const a: TokenBuckets = {
+			input: 100,
+			output: 200,
+			cacheRead: 50,
+			cacheWrite: 25,
+			totalTokens: 375,
+			costTotal: 0.05,
+		};
+		const b: TokenBuckets = {
+			input: 300,
+			output: 400,
+			cacheRead: 100,
+			cacheWrite: 75,
+			totalTokens: 875,
+			costTotal: 0.15,
+		};
+		const result = addBuckets(a, b);
+		expect(result.input).toBe(400);
+		expect(result.output).toBe(600);
+		expect(result.cacheRead).toBe(150);
+		expect(result.cacheWrite).toBe(100);
+		expect(result.totalTokens).toBe(1250);
+		expect(result.costTotal).toBe(0.2);
+	});
+
+	it("handles empty buckets", () => {
+		const a = emptyBuckets();
+		const b: TokenBuckets = {
+			input: 100,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 100,
+			costTotal: 0.01,
+		};
+		const result = addBuckets(a, b);
+		expect(result).toEqual(b);
+	});
+});
+
+describe("formatNumber", () => {
+	it("formats small numbers directly", () => {
+		expect(formatNumber(0)).toBe("0");
+		expect(formatNumber(42)).toBe("42");
+		expect(formatNumber(999)).toBe("999");
+	});
+
+	it("formats thousands with commas", () => {
+		expect(formatNumber(1000)).toBe("1,000");
+		expect(formatNumber(12345)).toBe("12.3K");
+	});
+
+	it("formats millions", () => {
+		expect(formatNumber(1_000_000)).toBe("1.0M");
+		expect(formatNumber(5_500_000)).toBe("5.5M");
+	});
+});
+
+describe("formatCost", () => {
+	it("formats zero", () => {
+		expect(formatCost(0)).toBe("$0.00");
+	});
+
+	it("formats small costs", () => {
+		expect(formatCost(0.005)).toBe("<$0.01");
+		expect(formatCost(0.01)).toBe("$0.01");
+		expect(formatCost(1.23)).toBe("$1.23");
+	});
+
+	it("formats large costs", () => {
+		expect(formatCost(1000)).toBe("$1.0K");
+		expect(formatCost(1234.56)).toBe("$1.2K");
+	});
+});
+
+describe("formatTokenSummary", () => {
+	it("formats full token breakdown", () => {
+		const tokens: TokenBuckets = {
+			input: 50000,
+			output: 10000,
+			cacheRead: 5000,
+			cacheWrite: 2000,
+			totalTokens: 67000,
+			costTotal: 0.45,
+		};
+		const result = formatTokenSummary(tokens);
+		expect(result).toContain("50.0K in");
+		expect(result).toContain("10.0K out");
+		expect(result).toContain("5,000 cached");
+		expect(result).toContain("$0.45");
+	});
+
+	it("omits zero fields", () => {
+		const tokens: TokenBuckets = {
+			input: 1000,
+			output: 500,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 1500,
+			costTotal: 0,
+		};
+		const result = formatTokenSummary(tokens);
+		expect(result).toContain("in");
+		expect(result).toContain("out");
+		expect(result).not.toContain("cached");
+		expect(result).not.toContain("$");
+	});
+
+	it("handles empty buckets", () => {
+		const result = formatTokenSummary(emptyBuckets());
+		expect(result).toBe("");
+	});
+});

--- a/src/lib/session-tokens.ts
+++ b/src/lib/session-tokens.ts
@@ -1,0 +1,399 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/** Aggregated token counts */
+export interface TokenBuckets {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalTokens: number;
+	costTotal: number;
+}
+
+export function emptyBuckets(): TokenBuckets {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		costTotal: 0,
+	};
+}
+
+export function addBuckets(a: TokenBuckets, b: TokenBuckets): TokenBuckets {
+	return {
+		input: a.input + b.input,
+		output: a.output + b.output,
+		cacheRead: a.cacheRead + b.cacheRead,
+		cacheWrite: a.cacheWrite + b.cacheWrite,
+		totalTokens: a.totalTokens + b.totalTokens,
+		costTotal: a.costTotal + b.costTotal,
+	};
+}
+
+/** Per-model usage row */
+export interface ModelUsage {
+	provider: string;
+	model: string;
+	tokens: TokenBuckets;
+	messageCount: number;
+}
+
+/** Per-session usage row */
+export interface SessionUsage {
+	sessionId: string;
+	sessionPath: string;
+	cwd: string;
+	name?: string;
+	created: Date;
+	tokens: TokenBuckets;
+	messageCount: number;
+}
+
+/** Full aggregation result */
+export interface AggregateResult {
+	totals: TokenBuckets;
+	byModel: ModelUsage[];
+	byProvider: Array<{
+		provider: string;
+		tokens: TokenBuckets;
+		messageCount: number;
+	}>;
+	bySession: SessionUsage[];
+	sessionCount: number;
+	messageCount: number;
+}
+
+/** Minimal assistant message fields for extraction */
+interface AssistantMessageData {
+	role: string;
+	provider?: string;
+	model?: string;
+	usage?: {
+		input?: number;
+		output?: number;
+		cacheRead?: number;
+		cacheWrite?: number;
+		totalTokens?: number;
+		cost?: {
+			input?: number;
+			output?: number;
+			cacheRead?: number;
+			cacheWrite?: number;
+			total?: number;
+		};
+	};
+}
+
+interface SessionEntry {
+	type: string;
+	message?: AssistantMessageData;
+	name?: string;
+}
+
+/**
+ * Find the pi sessions directory. Scans ~/.pi/agent/sessions/ for subdirectories.
+ */
+function getSessionsBaseDir(): string {
+	const agentDir =
+		process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	return join(agentDir, "sessions");
+}
+
+/**
+ * Discover all JSONL session files across all project directories.
+ */
+async function discoverSessionFiles(): Promise<string[]> {
+	const baseDir = getSessionsBaseDir();
+	const files: string[] = [];
+
+	let projectDirs: string[];
+	try {
+		const entries = await readdir(baseDir, { withFileTypes: true });
+		projectDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+	} catch {
+		return [];
+	}
+
+	for (const projectDir of projectDirs) {
+		const projectPath = join(baseDir, projectDir);
+		try {
+			const sessionEntries = await readdir(projectPath, {
+				withFileTypes: true,
+			});
+			for (const entry of sessionEntries) {
+				if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+					files.push(join(projectPath, entry.name));
+				}
+			}
+		} catch {
+			// skip inaccessible project dirs
+		}
+	}
+
+	return files;
+}
+
+/**
+ * Parse a single JSONL session file and extract token usage from assistant messages.
+ * Returns session metadata + per-model token aggregates.
+ */
+async function parseSessionFile(
+	filePath: string,
+): Promise<{ session: SessionUsage; models: Map<string, ModelUsage> } | null> {
+	let content: string;
+	try {
+		content = await readFile(filePath, "utf8");
+	} catch {
+		return null;
+	}
+
+	const lines = content.trim().split("\n");
+	if (lines.length === 0) return null;
+
+	const sessionTokens = emptyBuckets();
+	const models = new Map<string, ModelUsage>();
+	let sessionId = "";
+	let cwd = "";
+	let name: string | undefined;
+	let created: Date | undefined;
+	let messageCount = 0;
+
+	for (const line of lines) {
+		let entry: SessionEntry;
+		try {
+			entry = JSON.parse(line) as SessionEntry;
+		} catch {
+			continue;
+		}
+
+		// Extract session header
+		if (entry.type === "session") {
+			const header = entry as unknown as {
+				id?: string;
+				cwd?: string;
+				timestamp?: string;
+			};
+			sessionId = header.id ?? "";
+			cwd = header.cwd ?? "";
+			if (header.timestamp) {
+				created = new Date(header.timestamp);
+			}
+			continue;
+		}
+
+		// Extract session name
+		if (entry.type === "session_info" && entry.name) {
+			name = entry.name;
+			continue;
+		}
+
+		// Process assistant messages
+		if (entry.type === "message" && entry.message?.role === "assistant") {
+			const msg = entry.message;
+			const usage = msg.usage;
+			if (!usage) continue;
+
+			const buckets: TokenBuckets = {
+				input: usage.input ?? 0,
+				output: usage.output ?? 0,
+				cacheRead: usage.cacheRead ?? 0,
+				cacheWrite: usage.cacheWrite ?? 0,
+				totalTokens: usage.totalTokens ?? 0,
+				costTotal: usage.cost?.total ?? 0,
+			};
+
+			// Accumulate into session totals
+			sessionTokens.input += buckets.input;
+			sessionTokens.output += buckets.output;
+			sessionTokens.cacheRead += buckets.cacheRead;
+			sessionTokens.cacheWrite += buckets.cacheWrite;
+			sessionTokens.totalTokens += buckets.totalTokens;
+			sessionTokens.costTotal += buckets.costTotal;
+			messageCount++;
+
+			// Accumulate per-model
+			const provider = msg.provider ?? "unknown";
+			const model = msg.model ?? "unknown";
+			const modelKey = `${provider}/${model}`;
+			const existing = models.get(modelKey);
+			if (existing) {
+				existing.tokens = addBuckets(existing.tokens, buckets);
+				existing.messageCount++;
+			} else {
+				models.set(modelKey, {
+					provider,
+					model,
+					tokens: { ...buckets },
+					messageCount: 1,
+				});
+			}
+		}
+	}
+
+	if (messageCount === 0) return null;
+
+	// Get file creation time as fallback
+	let fileCreated = created ?? new Date(0);
+	if (!created) {
+		try {
+			const fileStat = await stat(filePath);
+			fileCreated = fileStat.birthtime;
+		} catch {
+			// keep default
+		}
+	}
+
+	return {
+		session: {
+			sessionId,
+			sessionPath: filePath,
+			cwd,
+			name,
+			created: fileCreated,
+			tokens: sessionTokens,
+			messageCount,
+		},
+		models,
+	};
+}
+
+/**
+ * Aggregate token usage across all sessions.
+ * Reads JSONL files directly for performance (avoids building session tree structures).
+ */
+export async function aggregateAllSessions(options?: {
+	cwd?: string;
+	since?: Date;
+	until?: Date;
+	limit?: number;
+}): Promise<AggregateResult> {
+	const files = await discoverSessionFiles();
+
+	const totals = emptyBuckets();
+	const byModelMap = new Map<string, ModelUsage>();
+	const byProviderMap = new Map<
+		string,
+		{ tokens: TokenBuckets; messageCount: number }
+	>();
+	const sessions: SessionUsage[] = [];
+	let totalMessages = 0;
+
+	// Parse files in parallel (bounded concurrency)
+	const CONCURRENCY = 16;
+	for (let i = 0; i < files.length; i += CONCURRENCY) {
+		const batch = files.slice(i, i + CONCURRENCY);
+		const results = await Promise.all(batch.map((f) => parseSessionFile(f)));
+
+		for (const result of results) {
+			if (!result) continue;
+			const { session, models } = result;
+
+			// Filter by cwd if specified
+			if (options?.cwd && session.cwd !== options.cwd) continue;
+
+			// Filter by time range
+			if (options?.since && session.created < options.since) continue;
+			if (options?.until && session.created > options.until) continue;
+
+			sessions.push(session);
+
+			// Accumulate totals
+			totals.input += session.tokens.input;
+			totals.output += session.tokens.output;
+			totals.cacheRead += session.tokens.cacheRead;
+			totals.cacheWrite += session.tokens.cacheWrite;
+			totals.totalTokens += session.tokens.totalTokens;
+			totals.costTotal += session.tokens.costTotal;
+			totalMessages += session.messageCount;
+
+			// Accumulate per-model
+			for (const [key, modelUsage] of models) {
+				const existing = byModelMap.get(key);
+				if (existing) {
+					existing.tokens = addBuckets(existing.tokens, modelUsage.tokens);
+					existing.messageCount += modelUsage.messageCount;
+				} else {
+					byModelMap.set(key, { ...modelUsage });
+				}
+
+				// Accumulate per-provider
+				const providerEntry = byProviderMap.get(modelUsage.provider);
+				if (providerEntry) {
+					providerEntry.tokens = addBuckets(
+						providerEntry.tokens,
+						modelUsage.tokens,
+					);
+					providerEntry.messageCount += modelUsage.messageCount;
+				} else {
+					byProviderMap.set(modelUsage.provider, {
+						tokens: { ...modelUsage.tokens },
+						messageCount: modelUsage.messageCount,
+					});
+				}
+			}
+		}
+	}
+
+	// Sort sessions by cost descending
+	sessions.sort((a, b) => b.tokens.costTotal - a.tokens.costTotal);
+
+	// Sort models by cost descending
+	const byModel = Array.from(byModelMap.values()).sort(
+		(a, b) => b.tokens.costTotal - a.tokens.costTotal,
+	);
+
+	// Sort providers by cost descending
+	const byProvider = Array.from(byProviderMap.entries())
+		.map(([provider, data]) => ({ provider, ...data }))
+		.sort((a, b) => b.tokens.costTotal - a.tokens.costTotal);
+
+	// Apply limit
+	const limit = options?.limit;
+	const limitedSessions = limit ? sessions.slice(0, limit) : sessions;
+
+	return {
+		totals,
+		byModel,
+		byProvider,
+		bySession: limitedSessions,
+		sessionCount: sessions.length,
+		messageCount: totalMessages,
+	};
+}
+
+/**
+ * Format a number with commas for readability.
+ */
+export function formatNumber(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 10_000) return `${(n / 1_000).toFixed(1)}K`;
+	if (n >= 1_000) return n.toLocaleString("en-US");
+	return String(n);
+}
+
+/**
+ * Format cost as USD string.
+ */
+export function formatCost(cost: number): string {
+	if (cost === 0) return "$0.00";
+	if (cost < 0.01) return "<$0.01";
+	if (cost >= 1000) return `$${(cost / 1000).toFixed(1)}K`;
+	return `$${cost.toFixed(2)}`;
+}
+
+/**
+ * Format token buckets as a compact summary line.
+ */
+export function formatTokenSummary(tokens: TokenBuckets): string {
+	const parts: string[] = [];
+	if (tokens.input > 0) parts.push(`${formatNumber(tokens.input)} in`);
+	if (tokens.output > 0) parts.push(`${formatNumber(tokens.output)} out`);
+	if (tokens.cacheRead > 0)
+		parts.push(`${formatNumber(tokens.cacheRead)} cached`);
+	if (tokens.costTotal > 0) parts.push(formatCost(tokens.costTotal));
+	return parts.join(" · ");
+}

--- a/src/providers/fetch.ts
+++ b/src/providers/fetch.ts
@@ -5,151 +5,160 @@ import { join } from "node:path";
 import type { AuthStorage } from "@mariozechner/pi-coding-agent";
 import type { QuotasResult, SupportedQuotaProvider } from "../types/quotas.js";
 import {
-  parseAnthropicUsage,
-  parseCodexUsage,
-  parseGitHubCopilotUsage,
-  parseOpenRouterUsage,
-  parseSyntheticUsage,
+	parseAnthropicUsage,
+	parseCodexUsage,
+	parseGitHubCopilotUsage,
+	parseOpenRouterUsage,
+	parseSyntheticUsage,
+	parseOpenCodeGoUsage,
 } from "./providers.js";
+import { resolveOpenCodeGoConfigCached } from "./opencode-go-config.js";
+import { queryOpenCodeGoQuota } from "./opencode-go.js";
 
 const FETCH_TIMEOUT_MS = 15_000;
 const COPILOT_VERSION = "0.35.0";
 const EDITOR_VERSION = "vscode/1.107.0";
 
 function isTimeoutReason(reason: unknown): boolean {
-  return (
-    (reason instanceof DOMException && reason.name === "TimeoutError") ||
-    (reason instanceof Error && reason.name === "TimeoutError")
-  );
+	return (
+		(reason instanceof DOMException && reason.name === "TimeoutError") ||
+		(reason instanceof Error && reason.name === "TimeoutError")
+	);
 }
 
 async function providerAccessToken(
-  authStorage: AuthStorage,
-  provider: string,
+	authStorage: AuthStorage,
+	provider: string,
 ): Promise<string | undefined> {
-  return authStorage.getApiKey(provider);
+	return authStorage.getApiKey(provider);
 }
 
 function codexAccountId(authStorage: AuthStorage): string | undefined {
-  const credential = authStorage.get("openai-codex") as any;
-  if (typeof credential?.accountId === "string") return credential.accountId;
-  try {
-    const authPath = join(homedir(), ".codex", "auth.json");
-    const data = JSON.parse(readFileSync(authPath, "utf8")) as any;
-    return data?.tokens?.account_id ?? data?.tokens?.accountId;
-  } catch {
-    return undefined;
-  }
+	const credential = authStorage.get("openai-codex") as any;
+	if (typeof credential?.accountId === "string") return credential.accountId;
+	try {
+		const authPath = join(homedir(), ".codex", "auth.json");
+		const data = JSON.parse(readFileSync(authPath, "utf8")) as any;
+		return data?.tokens?.account_id ?? data?.tokens?.accountId;
+	} catch {
+		return undefined;
+	}
 }
 
 type FetchJsonResult =
-  | { ok: true; data: any }
-  | {
-      ok: false;
-      status?: number;
-      message: string;
-      kind: "timeout" | "cancelled" | "http" | "network";
-    };
+	| { ok: true; data: any }
+	| {
+			ok: false;
+			status?: number;
+			message: string;
+			kind: "timeout" | "cancelled" | "http" | "network";
+	  };
 
 async function fetchJson(
-  url: string,
-  init: RequestInit,
-  signal?: AbortSignal,
+	url: string,
+	init: RequestInit,
+	signal?: AbortSignal,
 ): Promise<FetchJsonResult> {
-  const signals: AbortSignal[] = [AbortSignal.timeout(FETCH_TIMEOUT_MS)];
-  if (signal) signals.push(signal);
-  const combined = AbortSignal.any(signals);
+	const signals: AbortSignal[] = [AbortSignal.timeout(FETCH_TIMEOUT_MS)];
+	if (signal) signals.push(signal);
+	const combined = AbortSignal.any(signals);
 
-  try {
-    const response = await fetch(url, { ...init, signal: combined });
-    if (!response.ok) {
-      const body = await response.text().catch(() => "");
-      return {
-        ok: false,
-        status: response.status,
-        message: body || response.statusText || `HTTP ${response.status}`,
-        kind: "http",
-      };
-    }
-    return { ok: true, data: await response.json() };
-  } catch (err: unknown) {
-    const isAbort =
-      combined.aborted ||
-      (err instanceof DOMException && err.name === "AbortError");
-    if (isAbort) {
-      if (isTimeoutReason(combined.reason)) {
-        return { ok: false, message: "Request timed out", kind: "timeout" };
-      }
-      return { ok: false, message: "Request cancelled", kind: "cancelled" };
-    }
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return { ok: false, message, kind: "network" };
-  }
+	try {
+		const response = await fetch(url, { ...init, signal: combined });
+		if (!response.ok) {
+			const body = await response.text().catch(() => "");
+			return {
+				ok: false,
+				status: response.status,
+				message: body || response.statusText || `HTTP ${response.status}`,
+				kind: "http",
+			};
+		}
+		return { ok: true, data: await response.json() };
+	} catch (err: unknown) {
+		const isAbort =
+			combined.aborted ||
+			(err instanceof DOMException && err.name === "AbortError");
+		if (isAbort) {
+			if (isTimeoutReason(combined.reason)) {
+				return { ok: false, message: "Request timed out", kind: "timeout" };
+			}
+			return { ok: false, message: "Request cancelled", kind: "cancelled" };
+		}
+		const message = err instanceof Error ? err.message : "Unknown error";
+		return { ok: false, message, kind: "network" };
+	}
 }
 
-function success(provider: SupportedQuotaProvider, windows: ReturnType<typeof parseAnthropicUsage>): QuotasResult {
-  return { success: true, data: { provider, windows } };
+function success(
+	provider: SupportedQuotaProvider,
+	windows: ReturnType<typeof parseAnthropicUsage>,
+): QuotasResult {
+	return { success: true, data: { provider, windows } };
 }
 
-function failure(message: string, kind: "cancelled" | "timeout" | "config" | "http" | "network"): QuotasResult {
-  return { success: false, error: { message, kind } };
+function failure(
+	message: string,
+	kind: "cancelled" | "timeout" | "config" | "http" | "network",
+): QuotasResult {
+	return { success: false, error: { message, kind } };
 }
 
 export async function fetchAnthropicQuotasWithToken(
-  accessToken: string | undefined,
-  signal?: AbortSignal,
+	accessToken: string | undefined,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  if (!accessToken) return failure("No Anthropic OAuth token found", "config");
-  const result = await fetchJson(
-    "https://api.anthropic.com/api/oauth/usage",
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "anthropic-beta": "oauth-2025-04-20",
-        Accept: "application/json",
-      },
-    },
-    signal,
-  );
-  if (!result.ok) return failure(result.message, result.kind);
-  return success("anthropic", parseAnthropicUsage(result.data));
+	if (!accessToken) return failure("No Anthropic OAuth token found", "config");
+	const result = await fetchJson(
+		"https://api.anthropic.com/api/oauth/usage",
+		{
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"anthropic-beta": "oauth-2025-04-20",
+				Accept: "application/json",
+			},
+		},
+		signal,
+	);
+	if (!result.ok) return failure(result.message, result.kind);
+	return success("anthropic", parseAnthropicUsage(result.data));
 }
 
 export async function fetchCodexQuotasWithToken(
-  accessToken: string | undefined,
-  accountId: string | undefined,
-  signal?: AbortSignal,
+	accessToken: string | undefined,
+	accountId: string | undefined,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  if (!accessToken) return failure("No Codex access token found", "config");
-  if (!accountId) return failure("No Codex account id found", "config");
-  const result = await fetchJson(
-    "https://chatgpt.com/backend-api/wham/usage",
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "ChatGPT-Account-Id": accountId,
-        Accept: "application/json",
-        Origin: "https://chatgpt.com",
-        Referer: "https://chatgpt.com/",
-        "User-Agent": "Mozilla/5.0",
-      },
-    },
-    signal,
-  );
-  if (!result.ok) return failure(result.message, result.kind);
-  return success("openai-codex", parseCodexUsage(result.data));
+	if (!accessToken) return failure("No Codex access token found", "config");
+	if (!accountId) return failure("No Codex account id found", "config");
+	const result = await fetchJson(
+		"https://chatgpt.com/backend-api/wham/usage",
+		{
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"ChatGPT-Account-Id": accountId,
+				Accept: "application/json",
+				Origin: "https://chatgpt.com",
+				Referer: "https://chatgpt.com/",
+				"User-Agent": "Mozilla/5.0",
+			},
+		},
+		signal,
+	);
+	if (!result.ok) return failure(result.message, result.kind);
+	return success("openai-codex", parseCodexUsage(result.data));
 }
 
 function copilotHeaders(authHeader: string): Record<string, string> {
-  return {
-    Accept: "application/json",
-    Authorization: authHeader,
-    "User-Agent": `GitHubCopilotChat/${COPILOT_VERSION}`,
-    "Editor-Version": EDITOR_VERSION,
-    "Editor-Plugin-Version": `copilot-chat/${COPILOT_VERSION}`,
-    "Copilot-Integration-Id": "vscode-chat",
-    "Content-Type": "application/json",
-  };
+	return {
+		Accept: "application/json",
+		Authorization: authHeader,
+		"User-Agent": `GitHubCopilotChat/${COPILOT_VERSION}`,
+		"Editor-Version": EDITOR_VERSION,
+		"Editor-Plugin-Version": `copilot-chat/${COPILOT_VERSION}`,
+		"Copilot-Integration-Id": "vscode-chat",
+		"Content-Type": "application/json",
+	};
 }
 
 /**
@@ -157,178 +166,238 @@ function copilotHeaders(authHeader: string): Record<string, string> {
  * OAuth token is stale or the token exchange returns 401.
  */
 function ghCliToken(): string | undefined {
-  try {
-    return execFileSync("gh", ["auth", "token"], {
-      timeout: 5000,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim() || undefined;
-  } catch {
-    return undefined;
-  }
+	try {
+		return (
+			execFileSync("gh", ["auth", "token"], {
+				timeout: 5000,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "ignore"],
+			}).trim() || undefined
+		);
+	} catch {
+		return undefined;
+	}
 }
 
 async function tryGitHubUserEndpoint(
-  authHeader: string,
-  signal?: AbortSignal,
+	authHeader: string,
+	signal?: AbortSignal,
 ): Promise<FetchJsonResult> {
-  return fetchJson(
-    "https://api.github.com/copilot_internal/user",
-    { headers: copilotHeaders(authHeader) },
-    signal,
-  );
+	return fetchJson(
+		"https://api.github.com/copilot_internal/user",
+		{ headers: copilotHeaders(authHeader) },
+		signal,
+	);
 }
 
 function githubOAuthToken(authStorage: AuthStorage): string | undefined {
-  // Pi's GitHub Copilot OAuth credential stores the GitHub OAuth token in
-  // `refresh`; `access` is a Copilot proxy token (tid=...;proxy-ep=...) that
-  // is valid for model calls but rejected by api.github.com quota endpoints.
-  const credential = authStorage.get("github-copilot") as any;
-  if (credential?.type !== "oauth") return undefined;
-  return typeof credential.refresh === "string" && credential.refresh.length > 0
-    ? credential.refresh
-    : undefined;
+	// Pi's GitHub Copilot OAuth credential stores the GitHub OAuth token in
+	// `refresh`; `access` is a Copilot proxy token (tid=...;proxy-ep=...) that
+	// is valid for model calls but rejected by api.github.com quota endpoints.
+	const credential = authStorage.get("github-copilot") as any;
+	if (credential?.type !== "oauth") return undefined;
+	return typeof credential.refresh === "string" && credential.refresh.length > 0
+		? credential.refresh
+		: undefined;
 }
 
 async function fetchGitHubCopilotQuotasWithGitHubToken(
-  githubToken: string | undefined,
-  signal?: AbortSignal,
+	githubToken: string | undefined,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  if (!githubToken) return failure("No GitHub Copilot OAuth token found", "config");
+	if (!githubToken)
+		return failure("No GitHub Copilot OAuth token found", "config");
 
-  const bearerUsage = await tryGitHubUserEndpoint(`Bearer ${githubToken}`, signal);
-  if (bearerUsage.ok) return success("github-copilot", parseGitHubCopilotUsage(bearerUsage.data));
+	const bearerUsage = await tryGitHubUserEndpoint(
+		`Bearer ${githubToken}`,
+		signal,
+	);
+	if (bearerUsage.ok)
+		return success("github-copilot", parseGitHubCopilotUsage(bearerUsage.data));
 
-  const tokenUsage = await tryGitHubUserEndpoint(`token ${githubToken}`, signal);
-  if (tokenUsage.ok) return success("github-copilot", parseGitHubCopilotUsage(tokenUsage.data));
+	const tokenUsage = await tryGitHubUserEndpoint(
+		`token ${githubToken}`,
+		signal,
+	);
+	if (tokenUsage.ok)
+		return success("github-copilot", parseGitHubCopilotUsage(tokenUsage.data));
 
-  return failure(bearerUsage.message, bearerUsage.kind);
+	return failure(bearerUsage.message, bearerUsage.kind);
 }
 
 export async function fetchGitHubCopilotQuotasWithToken(
-  accessToken: string | undefined,
-  signal?: AbortSignal,
+	accessToken: string | undefined,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  if (!accessToken) return failure("No GitHub Copilot OAuth token found", "config");
+	if (!accessToken)
+		return failure("No GitHub Copilot OAuth token found", "config");
 
-  // 1) Try Copilot token exchange with stored Pi token
-  const exchange = await fetchJson(
-    "https://api.github.com/copilot_internal/v2/token",
-    { headers: copilotHeaders(`Bearer ${accessToken}`) },
-    signal,
-  );
+	// 1) Try Copilot token exchange with stored Pi token
+	const exchange = await fetchJson(
+		"https://api.github.com/copilot_internal/v2/token",
+		{ headers: copilotHeaders(`Bearer ${accessToken}`) },
+		signal,
+	);
 
-  if (exchange.ok && exchange.data?.token) {
-    const usage = await tryGitHubUserEndpoint(`Bearer ${exchange.data.token}`, signal);
-    if (usage.ok) return success("github-copilot", parseGitHubCopilotUsage(usage.data));
-  }
+	if (exchange.ok && exchange.data?.token) {
+		const usage = await tryGitHubUserEndpoint(
+			`Bearer ${exchange.data.token}`,
+			signal,
+		);
+		if (usage.ok)
+			return success("github-copilot", parseGitHubCopilotUsage(usage.data));
+	}
 
-  // 2) Try stored token directly
-  const directUsage = await tryGitHubUserEndpoint(`token ${accessToken}`, signal);
-  if (directUsage.ok) return success("github-copilot", parseGitHubCopilotUsage(directUsage.data));
+	// 2) Try stored token directly
+	const directUsage = await tryGitHubUserEndpoint(
+		`token ${accessToken}`,
+		signal,
+	);
+	if (directUsage.ok)
+		return success("github-copilot", parseGitHubCopilotUsage(directUsage.data));
 
-  // 3) Fallback: gh CLI token
-  const cliToken = ghCliToken();
-  if (cliToken && cliToken !== accessToken) {
-    const cliUsage = await tryGitHubUserEndpoint(`token ${cliToken}`, signal);
-    if (cliUsage.ok) return success("github-copilot", parseGitHubCopilotUsage(cliUsage.data));
-    return failure(cliUsage.message, cliUsage.kind);
-  }
+	// 3) Fallback: gh CLI token
+	const cliToken = ghCliToken();
+	if (cliToken && cliToken !== accessToken) {
+		const cliUsage = await tryGitHubUserEndpoint(`token ${cliToken}`, signal);
+		if (cliUsage.ok)
+			return success("github-copilot", parseGitHubCopilotUsage(cliUsage.data));
+		return failure(cliUsage.message, cliUsage.kind);
+	}
 
-  return failure(directUsage.message, directUsage.kind);
+	return failure(directUsage.message, directUsage.kind);
 }
 
 export async function fetchAnthropicQuotas(
-  authStorage: AuthStorage,
-  signal?: AbortSignal,
+	authStorage: AuthStorage,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  return fetchAnthropicQuotasWithToken(await providerAccessToken(authStorage, "anthropic"), signal);
+	return fetchAnthropicQuotasWithToken(
+		await providerAccessToken(authStorage, "anthropic"),
+		signal,
+	);
 }
 
 export async function fetchCodexQuotas(
-  authStorage: AuthStorage,
-  signal?: AbortSignal,
+	authStorage: AuthStorage,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  return fetchCodexQuotasWithToken(
-    await providerAccessToken(authStorage, "openai-codex"),
-    codexAccountId(authStorage),
-    signal,
-  );
+	return fetchCodexQuotasWithToken(
+		await providerAccessToken(authStorage, "openai-codex"),
+		codexAccountId(authStorage),
+		signal,
+	);
 }
 
 export async function fetchGitHubCopilotQuotas(
-  authStorage: AuthStorage,
-  signal?: AbortSignal,
+	authStorage: AuthStorage,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  const oauthResult = await fetchGitHubCopilotQuotasWithGitHubToken(
-    githubOAuthToken(authStorage),
-    signal,
-  );
-  if (
-    oauthResult.success ||
-    oauthResult.error.kind === "cancelled" ||
-    oauthResult.error.kind === "timeout"
-  ) {
-    return oauthResult;
-  }
+	const oauthResult = await fetchGitHubCopilotQuotasWithGitHubToken(
+		githubOAuthToken(authStorage),
+		signal,
+	);
+	if (
+		oauthResult.success ||
+		oauthResult.error.kind === "cancelled" ||
+		oauthResult.error.kind === "timeout"
+	) {
+		return oauthResult;
+	}
 
-  return fetchGitHubCopilotQuotasWithToken(
-    await providerAccessToken(authStorage, "github-copilot"),
-    signal,
-  );
+	return fetchGitHubCopilotQuotasWithToken(
+		await providerAccessToken(authStorage, "github-copilot"),
+		signal,
+	);
 }
 
 export async function fetchOpenRouterQuotasWithToken(
-  accessToken: string | undefined,
-  signal?: AbortSignal,
+	accessToken: string | undefined,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  if (!accessToken) return failure("No OpenRouter API key found", "config");
-  const result = await fetchJson(
-    "https://openrouter.ai/api/v1/key",
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: "application/json",
-      },
-    },
-    signal,
-  );
-  if (!result.ok) return failure(result.message, result.kind);
-  return success("openrouter", parseOpenRouterUsage(result.data));
+	if (!accessToken) return failure("No OpenRouter API key found", "config");
+	const result = await fetchJson(
+		"https://openrouter.ai/api/v1/key",
+		{
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				Accept: "application/json",
+			},
+		},
+		signal,
+	);
+	if (!result.ok) return failure(result.message, result.kind);
+	return success("openrouter", parseOpenRouterUsage(result.data));
 }
 
 export async function fetchOpenRouterQuotas(
-  authStorage: AuthStorage,
-  signal?: AbortSignal,
+	authStorage: AuthStorage,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  return fetchOpenRouterQuotasWithToken(
-    await providerAccessToken(authStorage, "openrouter"),
-    signal,
-  );
+	return fetchOpenRouterQuotasWithToken(
+		await providerAccessToken(authStorage, "openrouter"),
+		signal,
+	);
 }
 
 export async function fetchSyntheticQuotas(
-  _authStorage: AuthStorage,
-  signal?: AbortSignal,
+	_authStorage: AuthStorage,
+	signal?: AbortSignal,
 ): Promise<QuotasResult> {
-  const apiKey = process.env.SYNTHETIC_API_KEY;
-  if (!apiKey) return failure("No Synthetic API key found (set SYNTHETIC_API_KEY)", "config");
+	const apiKey = process.env.SYNTHETIC_API_KEY;
+	if (!apiKey)
+		return failure(
+			"No Synthetic API key found (set SYNTHETIC_API_KEY)",
+			"config",
+		);
 
-  const result = await fetchJson(
-    "https://api.synthetic.new/v2/quotas",
-    {
-      headers: { Authorization: `Bearer ${apiKey}` },
-    },
-    signal,
-  );
-  if (!result.ok) return failure(result.message, result.kind);
-  return success("synthetic", parseSyntheticUsage(result.data));
+	const result = await fetchJson(
+		"https://api.synthetic.new/v2/quotas",
+		{
+			headers: { Authorization: `Bearer ${apiKey}` },
+		},
+		signal,
+	);
+	if (!result.ok) return failure(result.message, result.kind);
+	return success("synthetic", parseSyntheticUsage(result.data));
+}
+
+export async function fetchOpenCodeGoQuotas(
+	_authStorage: AuthStorage,
+	signal?: AbortSignal,
+): Promise<QuotasResult> {
+	const configResult = await resolveOpenCodeGoConfigCached();
+	if (configResult.state === "none") {
+		return failure(
+			"No OpenCode Go config. Set OPENCODE_GO_WORKSPACE_ID +" +
+				" OPENCODE_GO_AUTH_COOKIE, or create" +
+				" ~/.config/opencode/opencode-quota/opencode-go.json",
+			"config",
+		);
+	}
+	if (configResult.state === "incomplete") {
+		return failure(
+			`OpenCode Go config incomplete: missing ${configResult.missing}`,
+			"config",
+		);
+	}
+	if (configResult.state === "invalid") {
+		return failure(
+			`OpenCode Go config invalid: ${configResult.error}`,
+			"config",
+		);
+	}
+
+	const result = await queryOpenCodeGoQuota(configResult.config, signal);
+	if (!result.success) return failure(result.error, "http");
+	return success("opencode-go", parseOpenCodeGoUsage(result));
 }
 
 export const PROVIDER_FETCHERS = {
-  anthropic: fetchAnthropicQuotas,
-  "openai-codex": fetchCodexQuotas,
-  "github-copilot": fetchGitHubCopilotQuotas,
-  openrouter: fetchOpenRouterQuotas,
-  synthetic: fetchSyntheticQuotas,
+	anthropic: fetchAnthropicQuotas,
+	"openai-codex": fetchCodexQuotas,
+	"github-copilot": fetchGitHubCopilotQuotas,
+	openrouter: fetchOpenRouterQuotas,
+	synthetic: fetchSyntheticQuotas,
+	"opencode-go": fetchOpenCodeGoQuotas,
 } as const;

--- a/src/providers/opencode-go-config.ts
+++ b/src/providers/opencode-go-config.ts
@@ -1,0 +1,127 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface OpenCodeGoConfig {
+	workspaceId: string;
+	authCookie: string;
+}
+
+export type ResolvedOpenCodeGoConfig =
+	| { state: "none" }
+	| { state: "configured"; config: OpenCodeGoConfig; source: string }
+	| { state: "incomplete"; source: string; missing: string }
+	| { state: "invalid"; source: string; error: string };
+
+function getConfigCandidatePaths(): string[] {
+	const home = homedir();
+	return [
+		join(home, ".config", "opencode", "opencode-quota", "opencode-go.json"),
+		join(home, ".config", "opencode-go", "config.json"),
+	];
+}
+
+async function readConfigFile(
+	path: string,
+): Promise<
+	| { state: "missing" }
+	| { state: "loaded"; config: Partial<OpenCodeGoConfig> }
+	| { state: "invalid"; error: string }
+> {
+	try {
+		const data = await readFile(path, "utf-8");
+		const parsed = JSON.parse(data) as Record<string, unknown>;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return {
+				state: "invalid",
+				error: "Config file must contain a JSON object",
+			};
+		}
+		return { state: "loaded", config: parsed as Partial<OpenCodeGoConfig> };
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+			return { state: "missing" };
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			state: "invalid",
+			error: `Failed to read config file: ${message}`,
+		};
+	}
+}
+
+export function resolveOpenCodeGoConfigFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): ResolvedOpenCodeGoConfig | null {
+	const workspaceId = env.OPENCODE_GO_WORKSPACE_ID?.trim();
+	const authCookie = env.OPENCODE_GO_AUTH_COOKIE?.trim();
+
+	if (!workspaceId && !authCookie) return null;
+
+	if (workspaceId && authCookie) {
+		return {
+			state: "configured",
+			config: { workspaceId, authCookie },
+			source: "env",
+		};
+	}
+
+	return {
+		state: "incomplete",
+		source: "env",
+		missing: workspaceId
+			? "OPENCODE_GO_AUTH_COOKIE"
+			: "OPENCODE_GO_WORKSPACE_ID",
+	};
+}
+
+export async function resolveOpenCodeGoConfig(): Promise<ResolvedOpenCodeGoConfig> {
+	const envResult = resolveOpenCodeGoConfigFromEnv();
+	if (envResult) return envResult;
+
+	const candidates = getConfigCandidatePaths();
+	for (const path of candidates) {
+		const fileResult = await readConfigFile(path);
+		if (fileResult.state === "missing") continue;
+		if (fileResult.state === "invalid") {
+			return { state: "invalid", source: path, error: fileResult.error };
+		}
+
+		const config = fileResult.config;
+		const workspaceId =
+			typeof config.workspaceId === "string" ? config.workspaceId.trim() : "";
+		const authCookie =
+			typeof config.authCookie === "string" ? config.authCookie.trim() : "";
+
+		if (workspaceId && authCookie) {
+			return {
+				state: "configured",
+				config: { workspaceId, authCookie },
+				source: path,
+			};
+		}
+
+		const missing = !workspaceId ? "workspaceId" : "authCookie";
+		return { state: "incomplete", source: path, missing };
+	}
+
+	return { state: "none" };
+}
+
+let cachedConfig: ResolvedOpenCodeGoConfig | null = null;
+let cachedAt = 0;
+
+const CACHE_MAX_AGE_MS = 30_000;
+
+export async function resolveOpenCodeGoConfigCached(params?: {
+	maxAgeMs?: number;
+}): Promise<ResolvedOpenCodeGoConfig> {
+	const maxAgeMs = Math.max(0, params?.maxAgeMs ?? CACHE_MAX_AGE_MS);
+	const now = Date.now();
+	if (cachedConfig && now - cachedAt < maxAgeMs) {
+		return cachedConfig;
+	}
+	cachedConfig = await resolveOpenCodeGoConfig();
+	cachedAt = now;
+	return cachedConfig;
+}

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -1,0 +1,183 @@
+/**
+ * OpenCode Go client.
+ *
+ * Fetches usage data from OpenCode Go dashboard using workspace ID and auth cookie.
+ * Scrapes SolidJS SSR hydration output for usage windows.
+ *
+ * Configuration:
+ * - Environment: OPENCODE_GO_WORKSPACE_ID + OPENCODE_GO_AUTH_COOKIE
+ * - Config file: ~/.config/opencode/opencode-quota/opencode-go.json
+ */
+
+const DASHBOARD_URL_PREFIX = "https://opencode.ai/workspace/";
+const DASHBOARD_URL_SUFFIX = "/go";
+const USER_AGENT =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Gecko/20100101 Firefox/148.0";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+const SCRAPED_NUMBER_PATTERN = String.raw`(-?\d+(?:\.\d+)?)`;
+
+const RE_ROLLING_PCT_FIRST = new RegExp(
+	String.raw`rollingUsage:\$R\[\d+\]=\{[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_ROLLING_RESET_FIRST = new RegExp(
+	String.raw`rollingUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+
+const RE_WEEKLY_PCT_FIRST = new RegExp(
+	String.raw`weeklyUsage:\$R\[\d+\]=\{[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_WEEKLY_RESET_FIRST = new RegExp(
+	String.raw`weeklyUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+
+const RE_MONTHLY_PCT_FIRST = new RegExp(
+	String.raw`monthlyUsage:\$R\[\d+\]=\{[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_MONTHLY_RESET_FIRST = new RegExp(
+	String.raw`monthlyUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+
+interface ScrapedWindowUsage {
+	usagePercent: number;
+	resetInSec: number;
+}
+
+export interface OpenCodeGoWindow {
+	usagePercent: number;
+	resetInSec: number;
+	percentRemaining: number;
+	resetTimeIso: string;
+}
+
+export interface OpenCodeGoQuotaResult {
+	success: true;
+	rolling?: OpenCodeGoWindow;
+	weekly?: OpenCodeGoWindow;
+	monthly?: OpenCodeGoWindow;
+}
+
+export interface OpenCodeGoQuotaError {
+	success: false;
+	error: string;
+}
+
+export type OpenCodeGoResult = OpenCodeGoQuotaResult | OpenCodeGoQuotaError;
+
+export interface OpenCodeGoConfig {
+	workspaceId: string;
+	authCookie: string;
+}
+
+function parseWindowUsage(
+	html: string,
+	rePctFirst: RegExp,
+	reResetFirst: RegExp,
+): ScrapedWindowUsage | null {
+	const pctFirstMatch = rePctFirst.exec(html);
+	if (pctFirstMatch) {
+		const usagePercent = Number(pctFirstMatch[1]);
+		const resetInSec = Number(pctFirstMatch[2]);
+		if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
+			return { usagePercent, resetInSec };
+		}
+	}
+
+	const resetFirstMatch = reResetFirst.exec(html);
+	if (resetFirstMatch) {
+		const resetInSec = Number(resetFirstMatch[1]);
+		const usagePercent = Number(resetFirstMatch[2]);
+		if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
+			return { usagePercent, resetInSec };
+		}
+	}
+
+	return null;
+}
+
+function normalizeWindowUsage(
+	window: ScrapedWindowUsage,
+	now: number,
+): OpenCodeGoWindow {
+	const usagePercent = Math.max(0, window.usagePercent);
+	const resetInSec = Math.max(0, window.resetInSec);
+	return {
+		usagePercent,
+		resetInSec,
+		percentRemaining: 100 - usagePercent,
+		resetTimeIso: new Date(now + resetInSec * 1000).toISOString(),
+	};
+}
+
+export async function queryOpenCodeGoQuota(
+	config: OpenCodeGoConfig,
+	signal?: AbortSignal,
+): Promise<OpenCodeGoResult> {
+	try {
+		const url = `${DASHBOARD_URL_PREFIX}${encodeURIComponent(config.workspaceId)}${DASHBOARD_URL_SUFFIX}`;
+		const signals: AbortSignal[] = [AbortSignal.timeout(REQUEST_TIMEOUT_MS)];
+		if (signal) signals.push(signal);
+		const combined = AbortSignal.any(signals);
+
+		const response = await fetch(url, {
+			method: "GET",
+			headers: {
+				"User-Agent": USER_AGENT,
+				Accept: "text/html",
+				Cookie: `auth=${config.authCookie}`,
+			},
+			signal: combined,
+		});
+
+		if (!response.ok) {
+			const text = await response.text().catch(() => "");
+			return {
+				success: false,
+				error: `OpenCode Go dashboard error ${response.status}: ${text.slice(0, 120)}`,
+			};
+		}
+
+		const html = await response.text();
+		const rolling = parseWindowUsage(
+			html,
+			RE_ROLLING_PCT_FIRST,
+			RE_ROLLING_RESET_FIRST,
+		);
+		const weekly = parseWindowUsage(
+			html,
+			RE_WEEKLY_PCT_FIRST,
+			RE_WEEKLY_RESET_FIRST,
+		);
+		const monthly = parseWindowUsage(
+			html,
+			RE_MONTHLY_PCT_FIRST,
+			RE_MONTHLY_RESET_FIRST,
+		);
+
+		if (!rolling && !weekly && !monthly) {
+			return {
+				success: false,
+				error: "Could not parse OpenCode Go dashboard usage windows",
+			};
+		}
+
+		const now = Date.now();
+		return {
+			success: true,
+			...(rolling ? { rolling: normalizeWindowUsage(rolling, now) } : {}),
+			...(weekly ? { weekly: normalizeWindowUsage(weekly, now) } : {}),
+			...(monthly ? { monthly: normalizeWindowUsage(monthly, now) } : {}),
+		};
+	} catch (err) {
+		if (err instanceof Error && err.name === "TimeoutError") {
+			return { success: false, error: "Request timed out" };
+		}
+		if (err instanceof Error && err.name === "AbortError") {
+			return { success: false, error: "Request cancelled" };
+		}
+		return {
+			success: false,
+			error: err instanceof Error ? err.message : "Unknown error",
+		};
+	}
+}

--- a/src/providers/parse.test.ts
+++ b/src/providers/parse.test.ts
@@ -4,540 +4,633 @@ import { parseCodexUsage } from "./providers.js";
 import { parseGitHubCopilotUsage } from "./providers.js";
 import { parseOpenRouterUsage } from "./providers.js";
 import { parseSyntheticUsage } from "./providers.js";
+import { parseOpenCodeGoUsage } from "./providers.js";
 
 describe("parseAnthropicUsage", () => {
-  it("maps oauth usage response into quota windows", () => {
-    const windows = parseAnthropicUsage({
-      five_hour: {
-        utilization: 23.4,
-        resets_at: "2026-04-22T18:30:00Z",
-      },
-      seven_day: {
-        utilization: 14.1,
-        resets_at: "2026-04-25T08:30:00Z",
-      },
-    });
+	it("maps oauth usage response into quota windows", () => {
+		const windows = parseAnthropicUsage({
+			five_hour: {
+				utilization: 23.4,
+				resets_at: "2026-04-22T18:30:00Z",
+			},
+			seven_day: {
+				utilization: 14.1,
+				resets_at: "2026-04-25T08:30:00Z",
+			},
+		});
 
-    expect(windows).toHaveLength(2);
-    expect(windows[0]).toMatchObject({
-      provider: "anthropic",
-      label: "5h",
-      usedPercent: 23.4,
-      windowSeconds: 5 * 60 * 60,
-    });
-    expect(windows[1]).toMatchObject({
-      provider: "anthropic",
-      label: "7d",
-      usedPercent: 14.1,
-      windowSeconds: 7 * 24 * 60 * 60,
-    });
-  });
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({
+			provider: "anthropic",
+			label: "5h",
+			usedPercent: 23.4,
+			windowSeconds: 5 * 60 * 60,
+		});
+		expect(windows[1]).toMatchObject({
+			provider: "anthropic",
+			label: "7d",
+			usedPercent: 14.1,
+			windowSeconds: 7 * 24 * 60 * 60,
+		});
+	});
 
-  it("includes extra_usage as a currency window", () => {
-    const windows = parseAnthropicUsage({
-      five_hour: { utilization: 9, resets_at: "2026-04-22T09:00:00Z" },
-      seven_day: { utilization: 31, resets_at: "2026-04-23T23:00:00Z" },
-      extra_usage: {
-        is_enabled: true,
-        monthly_limit: 30000,
-        used_credits: 21548,
-        utilization: 71.83,
-        currency: "AUD",
-      },
-    });
+	it("includes extra_usage as a currency window", () => {
+		const windows = parseAnthropicUsage({
+			five_hour: { utilization: 9, resets_at: "2026-04-22T09:00:00Z" },
+			seven_day: { utilization: 31, resets_at: "2026-04-23T23:00:00Z" },
+			extra_usage: {
+				is_enabled: true,
+				monthly_limit: 30000,
+				used_credits: 21548,
+				utilization: 71.83,
+				currency: "AUD",
+			},
+		});
 
-    const extra = windows.find((w) => w.label === "Extra (AUD)");
-    expect(extra).toBeDefined();
-    expect(extra).toMatchObject({
-      provider: "anthropic",
-      label: "Extra (AUD)",
-      isCurrency: true,
-      usedPercent: 71.83,
-      usedValue: 215.48,
-      limitValue: 300,
-    });
-  });
+		const extra = windows.find((w) => w.label === "Extra (AUD)");
+		expect(extra).toBeDefined();
+		expect(extra).toMatchObject({
+			provider: "anthropic",
+			label: "Extra (AUD)",
+			isCurrency: true,
+			usedPercent: 71.83,
+			usedValue: 215.48,
+			limitValue: 300,
+		});
+	});
 
-  it("includes per-model 7d windows when present", () => {
-    const windows = parseAnthropicUsage({
-      five_hour: { utilization: 9, resets_at: "2026-04-22T09:00:00Z" },
-      seven_day: { utilization: 31, resets_at: "2026-04-23T23:00:00Z" },
-      seven_day_sonnet: { utilization: 8, resets_at: "2026-04-23T23:00:00Z" },
-      seven_day_omelette: { utilization: 23, resets_at: "2026-04-26T23:00:00Z" },
-      seven_day_opus: null,
-    });
+	it("includes per-model 7d windows when present", () => {
+		const windows = parseAnthropicUsage({
+			five_hour: { utilization: 9, resets_at: "2026-04-22T09:00:00Z" },
+			seven_day: { utilization: 31, resets_at: "2026-04-23T23:00:00Z" },
+			seven_day_sonnet: { utilization: 8, resets_at: "2026-04-23T23:00:00Z" },
+			seven_day_omelette: {
+				utilization: 23,
+				resets_at: "2026-04-26T23:00:00Z",
+			},
+			seven_day_opus: null,
+		});
 
-    const sonnet = windows.find((w) => w.label === "7d Sonnet");
-    const opus = windows.find((w) => w.label === "7d Opus");
-    expect(sonnet).toMatchObject({ usedPercent: 8 });
-    expect(opus).toMatchObject({ usedPercent: 23 });
-  });
+		const sonnet = windows.find((w) => w.label === "7d Sonnet");
+		const opus = windows.find((w) => w.label === "7d Opus");
+		expect(sonnet).toMatchObject({ usedPercent: 8 });
+		expect(opus).toMatchObject({ usedPercent: 23 });
+	});
 
-  it("skips extra_usage when disabled", () => {
-    const windows = parseAnthropicUsage({
-      five_hour: { utilization: 5, resets_at: "2026-04-22T09:00:00Z" },
-      seven_day: { utilization: 10, resets_at: "2026-04-23T23:00:00Z" },
-      extra_usage: { is_enabled: false },
-    });
-    expect(windows.find((w) => w.label.startsWith("Extra"))).toBeUndefined();
-  });
+	it("skips extra_usage when disabled", () => {
+		const windows = parseAnthropicUsage({
+			five_hour: { utilization: 5, resets_at: "2026-04-22T09:00:00Z" },
+			seven_day: { utilization: 10, resets_at: "2026-04-23T23:00:00Z" },
+			extra_usage: { is_enabled: false },
+		});
+		expect(windows.find((w) => w.label.startsWith("Extra"))).toBeUndefined();
+	});
 });
 
 describe("parseCodexUsage", () => {
-  it("maps primary and secondary windows from wham usage", () => {
-    const windows = parseCodexUsage({
-      plan_type: "plus",
-      rate_limit: {
-        primary_window: {
-          used_percent: 27,
-          reset_at: 1776880800,
-          limit_window_seconds: 18000,
-        },
-        secondary_window: {
-          used_percent: 11,
-          reset_at: 1777485600,
-          limit_window_seconds: 604800,
-        },
-      },
-    });
+	it("maps primary and secondary windows from wham usage", () => {
+		const windows = parseCodexUsage({
+			plan_type: "plus",
+			rate_limit: {
+				primary_window: {
+					used_percent: 27,
+					reset_at: 1776880800,
+					limit_window_seconds: 18000,
+				},
+				secondary_window: {
+					used_percent: 11,
+					reset_at: 1777485600,
+					limit_window_seconds: 604800,
+				},
+			},
+		});
 
-    expect(windows).toHaveLength(2);
-    expect(windows[0]).toMatchObject({
-      provider: "openai-codex",
-      label: "5h",
-      usedPercent: 27,
-      windowSeconds: 18000,
-    });
-    expect(windows[1]).toMatchObject({
-      provider: "openai-codex",
-      label: "7d",
-      usedPercent: 11,
-      windowSeconds: 604800,
-    });
-  });
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({
+			provider: "openai-codex",
+			label: "5h",
+			usedPercent: 27,
+			windowSeconds: 18000,
+		});
+		expect(windows[1]).toMatchObject({
+			provider: "openai-codex",
+			label: "7d",
+			usedPercent: 11,
+			windowSeconds: 604800,
+		});
+	});
 
-  it("handles alternate field names", () => {
-    const windows = parseCodexUsage({
-      rate_limits: {
-        five_hour_limit: {
-          percent_left: 61,
-          reset_time_ms: 1776880800000,
-          limit_window_seconds: 18000,
-        },
-        weekly_limit: {
-          percent_left: 83,
-          reset_time_ms: 1777485600000,
-          limit_window_seconds: 604800,
-        },
-      },
-    });
+	it("handles alternate field names", () => {
+		const windows = parseCodexUsage({
+			rate_limits: {
+				five_hour_limit: {
+					percent_left: 61,
+					reset_time_ms: 1776880800000,
+					limit_window_seconds: 18000,
+				},
+				weekly_limit: {
+					percent_left: 83,
+					reset_time_ms: 1777485600000,
+					limit_window_seconds: 604800,
+				},
+			},
+		});
 
-    expect(windows[0]).toMatchObject({ usedPercent: 39, label: "5h" });
-    expect(windows[1]).toMatchObject({ usedPercent: 17, label: "7d" });
-  });
+		expect(windows[0]).toMatchObject({ usedPercent: 39, label: "5h" });
+		expect(windows[1]).toMatchObject({ usedPercent: 17, label: "7d" });
+	});
 
-  it("includes credits window when balance is present", () => {
-    const windows = parseCodexUsage({
-      plan_type: "team",
-      rate_limit: {
-        primary_window: { used_percent: 10, reset_at: 1776880800, limit_window_seconds: 18000 },
-      },
-      credits: {
-        has_credits: true,
-        unlimited: false,
-        balance: 4200,
-        approx_local_messages: 840,
-        approx_cloud_messages: 168,
-      },
-    });
+	it("includes credits window when balance is present", () => {
+		const windows = parseCodexUsage({
+			plan_type: "team",
+			rate_limit: {
+				primary_window: {
+					used_percent: 10,
+					reset_at: 1776880800,
+					limit_window_seconds: 18000,
+				},
+			},
+			credits: {
+				has_credits: true,
+				unlimited: false,
+				balance: 4200,
+				approx_local_messages: 840,
+				approx_cloud_messages: 168,
+			},
+		});
 
-    const credit = windows.find((w) => w.label === "Credits");
-    expect(credit).toBeDefined();
-    expect(credit).toMatchObject({ isCurrency: true, usedValue: 4200 });
-  });
+		const credit = windows.find((w) => w.label === "Credits");
+		expect(credit).toBeDefined();
+		expect(credit).toMatchObject({ isCurrency: true, usedValue: 4200 });
+	});
 
-  it("includes spend control status", () => {
-    const windows = parseCodexUsage({
-      plan_type: "team",
-      rate_limit: {
-        primary_window: { used_percent: 10, reset_at: 1776880800, limit_window_seconds: 18000 },
-      },
-      spend_control: { reached: true },
-    });
+	it("includes spend control status", () => {
+		const windows = parseCodexUsage({
+			plan_type: "team",
+			rate_limit: {
+				primary_window: {
+					used_percent: 10,
+					reset_at: 1776880800,
+					limit_window_seconds: 18000,
+				},
+			},
+			spend_control: { reached: true },
+		});
 
-    const sc = windows.find((w) => w.label === "Spend cap");
-    expect(sc).toBeDefined();
-    expect(sc).toMatchObject({ limited: true, usedPercent: 100 });
-  });
+		const sc = windows.find((w) => w.label === "Spend cap");
+		expect(sc).toBeDefined();
+		expect(sc).toMatchObject({ limited: true, usedPercent: 100 });
+	});
 
-  it("skips credits when no balance", () => {
-    const windows = parseCodexUsage({
-      rate_limit: {
-        primary_window: { used_percent: 10, reset_at: 1776880800, limit_window_seconds: 18000 },
-      },
-      credits: { has_credits: false, balance: null },
-    });
-    expect(windows.find((w) => w.label === "Credits")).toBeUndefined();
-  });
+	it("skips credits when no balance", () => {
+		const windows = parseCodexUsage({
+			rate_limit: {
+				primary_window: {
+					used_percent: 10,
+					reset_at: 1776880800,
+					limit_window_seconds: 18000,
+				},
+			},
+			credits: { has_credits: false, balance: null },
+		});
+		expect(windows.find((w) => w.label === "Credits")).toBeUndefined();
+	});
 });
 
 describe("parseGitHubCopilotUsage", () => {
-  it("maps premium interaction quota snapshot", () => {
-    const windows = parseGitHubCopilotUsage({
-      copilot_plan: "pro",
-      quota_reset_date: "2026-05-01T00:00:00Z",
-      quota_snapshots: {
-        premium_interactions: {
-          entitlement: 300,
-          remaining: 240,
-          percent_remaining: 80,
-          quota_id: "premium",
-        },
-        chat: {
-          entitlement: 1000,
-          remaining: 950,
-          percent_remaining: 95,
-          quota_id: "chat",
-        },
-      },
-    });
+	it("maps premium interaction quota snapshot", () => {
+		const windows = parseGitHubCopilotUsage({
+			copilot_plan: "pro",
+			quota_reset_date: "2026-05-01T00:00:00Z",
+			quota_snapshots: {
+				premium_interactions: {
+					entitlement: 300,
+					remaining: 240,
+					percent_remaining: 80,
+					quota_id: "premium",
+				},
+				chat: {
+					entitlement: 1000,
+					remaining: 950,
+					percent_remaining: 95,
+					quota_id: "chat",
+				},
+			},
+		});
 
-    expect(windows).toHaveLength(2);
-    expect(windows[0]).toMatchObject({
-      provider: "github-copilot",
-      label: "Premium / month",
-      usedPercent: 20,
-      usedValue: 60,
-      limitValue: 300,
-    });
-    expect(windows[1]).toMatchObject({
-      provider: "github-copilot",
-      label: "Chat / month",
-      usedPercent: 5,
-      usedValue: 50,
-      limitValue: 1000,
-    });
-  });
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({
+			provider: "github-copilot",
+			label: "Premium / month",
+			usedPercent: 20,
+			usedValue: 60,
+			limitValue: 300,
+		});
+		expect(windows[1]).toMatchObject({
+			provider: "github-copilot",
+			label: "Chat / month",
+			usedPercent: 5,
+			usedValue: 50,
+			limitValue: 1000,
+		});
+	});
 
-  it("includes overage info on premium interactions", () => {
-    const windows = parseGitHubCopilotUsage({
-      copilot_plan: "business",
-      quota_reset_date: "2026-05-01T00:00:00Z",
-      quota_snapshots: {
-        premium_interactions: {
-          entitlement: 300,
-          remaining: 293,
-          percent_remaining: 97.8,
-          overage_count: 5,
-          overage_permitted: true,
-        },
-      },
-    });
+	it("includes overage info on premium interactions", () => {
+		const windows = parseGitHubCopilotUsage({
+			copilot_plan: "business",
+			quota_reset_date: "2026-05-01T00:00:00Z",
+			quota_snapshots: {
+				premium_interactions: {
+					entitlement: 300,
+					remaining: 293,
+					percent_remaining: 97.8,
+					overage_count: 5,
+					overage_permitted: true,
+				},
+			},
+		});
 
-    const premium = windows.find((w) => w.label === "Premium / month");
-    expect(premium).toBeDefined();
-    expect(premium!.nextAmount).toBe("+5 overage");
-  });
+		const premium = windows.find((w) => w.label === "Premium / month");
+		expect(premium).toBeDefined();
+		expect(premium!.nextAmount).toBe("+5 overage");
+	});
 
-  it("handles free-tier completions data", () => {
-    const windows = parseGitHubCopilotUsage({
-      access_type_sku: "free_limited_copilot",
-      limited_user_reset_date: "2026-05-01",
-      monthly_quotas: {
-        chat: 500,
-        completions: 4000,
-      },
-      limited_user_quotas: {
-        chat: 410,
-        completions: 4000,
-      },
-    });
+	it("handles free-tier completions data", () => {
+		const windows = parseGitHubCopilotUsage({
+			access_type_sku: "free_limited_copilot",
+			limited_user_reset_date: "2026-05-01",
+			monthly_quotas: {
+				chat: 500,
+				completions: 4000,
+			},
+			limited_user_quotas: {
+				chat: 410,
+				completions: 4000,
+			},
+		});
 
-    expect(windows).toHaveLength(2);
-    expect(windows[0]).toMatchObject({ label: "Chat / month", usedPercent: 18 });
-    expect(windows[1]).toMatchObject({ label: "Completions / month", usedPercent: 0 });
-  });
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({
+			label: "Chat / month",
+			usedPercent: 18,
+		});
+		expect(windows[1]).toMatchObject({
+			label: "Completions / month",
+			usedPercent: 0,
+		});
+	});
 });
 
 describe("parseOpenRouterUsage", () => {
-  it("maps API response with monthly budget limit", () => {
-    const windows = parseOpenRouterUsage({
-      data: {
-        label: "Test Key",
-        limit: 50,
-        limit_remaining: 35,
-        limit_reset: "monthly",
-        usage: 15,
-        usage_daily: 2.5,
-        usage_weekly: 12,
-        usage_monthly: 15,
-        byok_usage: 0,
-        byok_usage_daily: 0,
-        byok_usage_weekly: 0,
-        byok_usage_monthly: 0,
-        creator_user_id: "user123",
-        include_byok_in_limit: false,
-        is_free_tier: false,
-        is_management_key: false,
-        is_provisioning_key: false,
-      },
-    });
+	it("maps API response with monthly budget limit", () => {
+		const windows = parseOpenRouterUsage({
+			data: {
+				label: "Test Key",
+				limit: 50,
+				limit_remaining: 35,
+				limit_reset: "monthly",
+				usage: 15,
+				usage_daily: 2.5,
+				usage_weekly: 12,
+				usage_monthly: 15,
+				byok_usage: 0,
+				byok_usage_daily: 0,
+				byok_usage_weekly: 0,
+				byok_usage_monthly: 0,
+				creator_user_id: "user123",
+				include_byok_in_limit: false,
+				is_free_tier: false,
+				is_management_key: false,
+				is_provisioning_key: false,
+			},
+		});
 
-    // When limit is set, we get: Monthly Budget + Daily + Weekly + Monthly = 4 windows
-    expect(windows).toHaveLength(4);
+		// When limit is set, we get: Monthly Budget + Daily + Weekly + Monthly = 4 windows
+		expect(windows).toHaveLength(4);
 
-    // Monthly Budget window
-    const budget = windows.find((w) => w.label === "Monthly Budget");
-    expect(budget).toBeDefined();
-    expect(budget).toMatchObject({
-      provider: "openrouter",
-      label: "Monthly Budget",
-      usedPercent: 30, // 15/50 = 30%
-      isCurrency: true,
-      usedValue: 15,
-      limitValue: 50,
-      showPace: true,
-    });
+		// Monthly Budget window
+		const budget = windows.find((w) => w.label === "Monthly Budget");
+		expect(budget).toBeDefined();
+		expect(budget).toMatchObject({
+			provider: "openrouter",
+			label: "Monthly Budget",
+			usedPercent: 30, // 15/50 = 30%
+			isCurrency: true,
+			usedValue: 15,
+			limitValue: 50,
+			showPace: true,
+		});
 
-    // Daily, Weekly, Monthly usage windows
-    expect(windows.find((w) => w.label === "Daily")).toBeDefined();
-    expect(windows.find((w) => w.label === "Weekly")).toBeDefined();
-    expect(windows.find((w) => w.label === "Monthly")).toBeDefined();
-  });
+		// Daily, Weekly, Monthly usage windows
+		expect(windows.find((w) => w.label === "Daily")).toBeDefined();
+		expect(windows.find((w) => w.label === "Weekly")).toBeDefined();
+		expect(windows.find((w) => w.label === "Monthly")).toBeDefined();
+	});
 
-  it("maps unlimited key with remaining credits", () => {
-    const windows = parseOpenRouterUsage({
-      data: {
-        label: "Unlimited Key",
-        limit: null,
-        limit_remaining: 100,
-        limit_reset: null,
-        usage: 50,
-        usage_daily: 5,
-        usage_weekly: 20,
-        usage_monthly: 50,
-        byok_usage: 0,
-        byok_usage_daily: 0,
-        byok_usage_weekly: 0,
-        byok_usage_monthly: 0,
-        creator_user_id: "user123",
-        include_byok_in_limit: false,
-        is_free_tier: false,
-        is_management_key: false,
-        is_provisioning_key: false,
-      },
-    });
+	it("maps unlimited key with remaining credits", () => {
+		const windows = parseOpenRouterUsage({
+			data: {
+				label: "Unlimited Key",
+				limit: null,
+				limit_remaining: 100,
+				limit_reset: null,
+				usage: 50,
+				usage_daily: 5,
+				usage_weekly: 20,
+				usage_monthly: 50,
+				byok_usage: 0,
+				byok_usage_daily: 0,
+				byok_usage_weekly: 0,
+				byok_usage_monthly: 0,
+				creator_user_id: "user123",
+				include_byok_in_limit: false,
+				is_free_tier: false,
+				is_management_key: false,
+				is_provisioning_key: false,
+			},
+		});
 
-    // When unlimited with limit_remaining: Credits Remaining + Daily + Weekly + Monthly = 4 windows
-    expect(windows).toHaveLength(4);
+		// When unlimited with limit_remaining: Credits Remaining + Daily + Weekly + Monthly = 4 windows
+		expect(windows).toHaveLength(4);
 
-    // Credits Remaining window
-    const remaining = windows.find((w) => w.label === "Credits Remaining");
-    expect(remaining).toBeDefined();
-    expect(remaining).toMatchObject({
-      provider: "openrouter",
-      label: "Credits Remaining",
-      usedPercent: 0,
-      isCurrency: true,
-      usedValue: 100,
-      limitValue: 100,
-      showPace: false,
-    });
-  });
+		// Credits Remaining window
+		const remaining = windows.find((w) => w.label === "Credits Remaining");
+		expect(remaining).toBeDefined();
+		expect(remaining).toMatchObject({
+			provider: "openrouter",
+			label: "Credits Remaining",
+			usedPercent: 0,
+			isCurrency: true,
+			usedValue: 100,
+			limitValue: 100,
+			showPace: false,
+		});
+	});
 
-  it("handles zero usage", () => {
-    const windows = parseOpenRouterUsage({
-      data: {
-        label: "Test Key",
-        limit: 100,
-        limit_remaining: 100,
-        limit_reset: "monthly",
-        usage: 0,
-        usage_daily: 0,
-        usage_weekly: 0,
-        usage_monthly: 0,
-        byok_usage: 0,
-        byok_usage_daily: 0,
-        byok_usage_weekly: 0,
-        byok_usage_monthly: 0,
-        creator_user_id: "user123",
-        include_byok_in_limit: false,
-        is_free_tier: false,
-        is_management_key: false,
-        is_provisioning_key: false,
-      },
-    });
+	it("handles zero usage", () => {
+		const windows = parseOpenRouterUsage({
+			data: {
+				label: "Test Key",
+				limit: 100,
+				limit_remaining: 100,
+				limit_reset: "monthly",
+				usage: 0,
+				usage_daily: 0,
+				usage_weekly: 0,
+				usage_monthly: 0,
+				byok_usage: 0,
+				byok_usage_daily: 0,
+				byok_usage_weekly: 0,
+				byok_usage_monthly: 0,
+				creator_user_id: "user123",
+				include_byok_in_limit: false,
+				is_free_tier: false,
+				is_management_key: false,
+				is_provisioning_key: false,
+			},
+		});
 
-    const budget = windows.find((w) => w.label === "Monthly Budget");
-    expect(budget).toBeDefined();
-    expect(budget!.usedPercent).toBe(0);
-  });
+		const budget = windows.find((w) => w.label === "Monthly Budget");
+		expect(budget).toBeDefined();
+		expect(budget!.usedPercent).toBe(0);
+	});
 
-  it("returns empty array when no data", () => {
-    const windows = parseOpenRouterUsage({});
-    expect(windows).toHaveLength(0);
-  });
+	it("returns empty array when no data", () => {
+		const windows = parseOpenRouterUsage({});
+		expect(windows).toHaveLength(0);
+	});
 
-  it("handles missing limit_remaining for unlimited keys", () => {
-    const windows = parseOpenRouterUsage({
-      data: {
-        label: "Test Key",
-        limit: null,
-        limit_remaining: null,
-        limit_reset: null,
-        usage: 25,
-        usage_daily: 3,
-        usage_weekly: 10,
-        usage_monthly: 25,
-        byok_usage: 0,
-        byok_usage_daily: 0,
-        byok_usage_weekly: 0,
-        byok_usage_monthly: 0,
-        creator_user_id: "user123",
-        include_byok_in_limit: false,
-        is_free_tier: false,
-        is_management_key: false,
-        is_provisioning_key: false,
-      },
-    });
+	it("handles missing limit_remaining for unlimited keys", () => {
+		const windows = parseOpenRouterUsage({
+			data: {
+				label: "Test Key",
+				limit: null,
+				limit_remaining: null,
+				limit_reset: null,
+				usage: 25,
+				usage_daily: 3,
+				usage_weekly: 10,
+				usage_monthly: 25,
+				byok_usage: 0,
+				byok_usage_daily: 0,
+				byok_usage_weekly: 0,
+				byok_usage_monthly: 0,
+				creator_user_id: "user123",
+				include_byok_in_limit: false,
+				is_free_tier: false,
+				is_management_key: false,
+				is_provisioning_key: false,
+			},
+		});
 
-    // Should not have "Credits Remaining" window if limit_remaining is null
-    const remaining = windows.find((w) => w.label === "Credits Remaining");
-    expect(remaining).toBeUndefined();
+		// Should not have "Credits Remaining" window if limit_remaining is null
+		const remaining = windows.find((w) => w.label === "Credits Remaining");
+		expect(remaining).toBeUndefined();
 
-    // But should still have usage tracking windows
-    expect(windows.find((w) => w.label === "Daily")).toBeDefined();
-    expect(windows.find((w) => w.label === "Weekly")).toBeDefined();
-    expect(windows.find((w) => w.label === "Monthly")).toBeDefined();
-  });
+		// But should still have usage tracking windows
+		expect(windows.find((w) => w.label === "Daily")).toBeDefined();
+		expect(windows.find((w) => w.label === "Weekly")).toBeDefined();
+		expect(windows.find((w) => w.label === "Monthly")).toBeDefined();
+	});
 });
 
 describe("parseSyntheticUsage", () => {
-  it("parses a full API response with all windows", () => {
-    const windows = parseSyntheticUsage({
-      subscription: {
-        limit: 500,
-        requests: 0,
-        renewsAt: "2026-05-06T12:27:17.097Z",
-      },
-      search: {
-        hourly: {
-          limit: 250,
-          requests: 30,
-          renewsAt: "2026-05-06T08:27:17.097Z",
-        },
-      },
-      freeToolCalls: {
-        limit: 0,
-        requests: 0,
-        renewsAt: "2026-05-07T07:27:17.102Z",
-      },
-      weeklyTokenLimit: {
-        nextRegenAt: "2026-05-06T09:44:14.000Z",
-        percentRemaining: 96.39,
-        maxCredits: "$24.00",
-        remainingCredits: "$23.13",
-        nextRegenCredits: "$0.48",
-      },
-      rollingFiveHourLimit: {
-        nextTickAt: "2026-05-06T07:27:51.000Z",
-        tickPercent: 0.05,
-        remaining: 420,
-        max: 500,
-        limited: false,
-      },
-    });
+	it("parses a full API response with all windows", () => {
+		const windows = parseSyntheticUsage({
+			subscription: {
+				limit: 500,
+				requests: 0,
+				renewsAt: "2026-05-06T12:27:17.097Z",
+			},
+			search: {
+				hourly: {
+					limit: 250,
+					requests: 30,
+					renewsAt: "2026-05-06T08:27:17.097Z",
+				},
+			},
+			freeToolCalls: {
+				limit: 0,
+				requests: 0,
+				renewsAt: "2026-05-07T07:27:17.102Z",
+			},
+			weeklyTokenLimit: {
+				nextRegenAt: "2026-05-06T09:44:14.000Z",
+				percentRemaining: 96.39,
+				maxCredits: "$24.00",
+				remainingCredits: "$23.13",
+				nextRegenCredits: "$0.48",
+			},
+			rollingFiveHourLimit: {
+				nextTickAt: "2026-05-06T07:27:51.000Z",
+				tickPercent: 0.05,
+				remaining: 420,
+				max: 500,
+				limited: false,
+			},
+		});
 
-    // subscription is NOT a window (matching pi-synthetic extension)
-    expect(windows.find((w) => w.label === "Subscription")).toBeUndefined();
+		// subscription is NOT a window (matching pi-synthetic extension)
+		expect(windows.find((w) => w.label === "Subscription")).toBeUndefined();
 
-    // weeklyTokenLimit: 100 - 96.39 = ~3.61%
-    const credits = windows.find((w) => w.label === "Credits / week");
-    expect(credits).toBeDefined();
-    expect(credits!.usedPercent).toBeCloseTo(3.61, 1);
-    expect(credits!.isCurrency).toBe(true);
-    expect(credits!.limitValue).toBe(24);
-    expect(credits!.usedValue).toBeCloseTo(0.87, 1);
-    expect(credits!.paceScale).toBe(1 / 7);
-    expect(credits!.nextAmount).toBe("+$0.48");
+		// weeklyTokenLimit: 100 - 96.39 = ~3.61%
+		const credits = windows.find((w) => w.label === "Credits / week");
+		expect(credits).toBeDefined();
+		expect(credits!.usedPercent).toBeCloseTo(3.61, 1);
+		expect(credits!.isCurrency).toBe(true);
+		expect(credits!.limitValue).toBe(24);
+		expect(credits!.usedValue).toBeCloseTo(0.87, 1);
+		expect(credits!.paceScale).toBe(1 / 7);
+		expect(credits!.nextAmount).toBe("+$0.48");
 
-    // rollingFiveHourLimit: (500-420)/500 = 16%
-    const fiveHour = windows.find((w) => w.label === "Requests / 5h");
-    expect(fiveHour).toBeDefined();
-    expect(fiveHour!.usedPercent).toBe(16);
-    expect(fiveHour!.usedValue).toBe(80);
-    expect(fiveHour!.limitValue).toBe(500);
-    expect(fiveHour!.limited).toBe(false);
+		// rollingFiveHourLimit: (500-420)/500 = 16%
+		const fiveHour = windows.find((w) => w.label === "Requests / 5h");
+		expect(fiveHour).toBeDefined();
+		expect(fiveHour!.usedPercent).toBe(16);
+		expect(fiveHour!.usedValue).toBe(80);
+		expect(fiveHour!.limitValue).toBe(500);
+		expect(fiveHour!.limited).toBe(false);
 
-    // search hourly
-    const search = windows.find((w) => w.label === "Search / hour");
-    expect(search).toBeDefined();
-    expect(search!.usedPercent).toBeCloseTo(12, 0);
-    expect(search!.usedValue).toBe(30);
-    expect(search!.limitValue).toBe(250);
+		// search hourly
+		const search = windows.find((w) => w.label === "Search / hour");
+		expect(search).toBeDefined();
+		expect(search!.usedPercent).toBeCloseTo(12, 0);
+		expect(search!.usedValue).toBe(30);
+		expect(search!.limitValue).toBe(250);
 
-    // freeToolCalls with limit=0 is NOT shown
-    expect(windows.find((w) => w.label === "Free Tool Calls / day")).toBeUndefined();
-  });
+		// freeToolCalls with limit=0 is NOT shown
+		expect(
+			windows.find((w) => w.label === "Free Tool Calls / day"),
+		).toBeUndefined();
+	});
 
-  it("shows freeToolCalls when limit > 0", () => {
-    const windows = parseSyntheticUsage({
-      weeklyTokenLimit: {
-        nextRegenAt: "2026-05-06T09:44:14.000Z",
-        percentRemaining: 50,
-        maxCredits: "$10.00",
-        remainingCredits: "$5.00",
-        nextRegenCredits: "$0.50",
-      },
-      freeToolCalls: {
-        limit: 100,
-        requests: 25,
-        renewsAt: "2026-05-07T07:27:17.102Z",
-      },
-    });
+	it("shows freeToolCalls when limit > 0", () => {
+		const windows = parseSyntheticUsage({
+			weeklyTokenLimit: {
+				nextRegenAt: "2026-05-06T09:44:14.000Z",
+				percentRemaining: 50,
+				maxCredits: "$10.00",
+				remainingCredits: "$5.00",
+				nextRegenCredits: "$0.50",
+			},
+			freeToolCalls: {
+				limit: 100,
+				requests: 25,
+				renewsAt: "2026-05-07T07:27:17.102Z",
+			},
+		});
 
-    const tools = windows.find((w) => w.label === "Free Tool Calls / day");
-    expect(tools).toBeDefined();
-    expect(tools!.usedPercent).toBe(25);
-  });
+		const tools = windows.find((w) => w.label === "Free Tool Calls / day");
+		expect(tools).toBeDefined();
+		expect(tools!.usedPercent).toBe(25);
+	});
 
-  it("parses currency strings like $24.00 correctly", () => {
-    const windows = parseSyntheticUsage({
-      weeklyTokenLimit: {
-        nextRegenAt: "2026-05-06T09:44:14.000Z",
-        percentRemaining: 75,
-        maxCredits: "$1,234.56",
-        remainingCredits: "$925.92",
-        nextRegenCredits: "$12.34",
-      },
-    });
+	it("parses currency strings like $24.00 correctly", () => {
+		const windows = parseSyntheticUsage({
+			weeklyTokenLimit: {
+				nextRegenAt: "2026-05-06T09:44:14.000Z",
+				percentRemaining: 75,
+				maxCredits: "$1,234.56",
+				remainingCredits: "$925.92",
+				nextRegenCredits: "$12.34",
+			},
+		});
 
-    const credits = windows.find((w) => w.label === "Credits / week");
-    expect(credits).toBeDefined();
-    expect(credits!.limitValue).toBe(1234.56);
-    expect(credits!.usedValue).toBeCloseTo(308.64, 1);
-    expect(credits!.usedPercent).toBe(25); // 100 - 75
-  });
+		const credits = windows.find((w) => w.label === "Credits / week");
+		expect(credits).toBeDefined();
+		expect(credits!.limitValue).toBe(1234.56);
+		expect(credits!.usedValue).toBeCloseTo(308.64, 1);
+		expect(credits!.usedPercent).toBe(25); // 100 - 75
+	});
 
-  it("handles limited state", () => {
-    const windows = parseSyntheticUsage({
-      rollingFiveHourLimit: {
-        nextTickAt: "2026-05-06T07:27:51.000Z",
-        tickPercent: 100,
-        remaining: 0,
-        max: 500,
-        limited: true,
-      },
-    });
+	it("handles limited state", () => {
+		const windows = parseSyntheticUsage({
+			rollingFiveHourLimit: {
+				nextTickAt: "2026-05-06T07:27:51.000Z",
+				tickPercent: 100,
+				remaining: 0,
+				max: 500,
+				limited: true,
+			},
+		});
 
-    const fiveHour = windows.find((w) => w.label === "Requests / 5h");
-    expect(fiveHour).toBeDefined();
-    expect(fiveHour!.usedPercent).toBe(100);
-    expect(fiveHour!.limited).toBe(true);
-  });
+		const fiveHour = windows.find((w) => w.label === "Requests / 5h");
+		expect(fiveHour).toBeDefined();
+		expect(fiveHour!.usedPercent).toBe(100);
+		expect(fiveHour!.limited).toBe(true);
+	});
 
-  it("returns empty array when no data", () => {
-    const windows = parseSyntheticUsage({});
-    expect(windows).toHaveLength(0);
-  });
+	it("returns empty array when no data", () => {
+		const windows = parseSyntheticUsage({});
+		expect(windows).toHaveLength(0);
+	});
+});
+
+describe("parseOpenCodeGoUsage", () => {
+	it("parses rolling, weekly, and monthly windows", () => {
+		const windows = parseOpenCodeGoUsage({
+			rolling: {
+				usagePercent: 35,
+				resetInSec: 12000,
+				percentRemaining: 65,
+				resetTimeIso: "2026-05-18T22:00:00Z",
+			},
+			weekly: {
+				usagePercent: 62,
+				resetInSec: 500000,
+				percentRemaining: 38,
+				resetTimeIso: "2026-05-25T00:00:00Z",
+			},
+			monthly: {
+				usagePercent: 28,
+				resetInSec: 1200000,
+				percentRemaining: 72,
+				resetTimeIso: "2026-06-01T00:00:00Z",
+			},
+		});
+
+		expect(windows).toHaveLength(3);
+
+		expect(windows[0]).toMatchObject({
+			provider: "opencode-go",
+			label: "5h Rolling",
+			usedPercent: 35,
+			windowSeconds: 5 * 60 * 60,
+		});
+
+		expect(windows[1]).toMatchObject({
+			provider: "opencode-go",
+			label: "Weekly",
+			usedPercent: 62,
+			windowSeconds: 7 * 24 * 60 * 60,
+			showPace: true,
+		});
+
+		expect(windows[2]).toMatchObject({
+			provider: "opencode-go",
+			label: "Monthly",
+			usedPercent: 28,
+			windowSeconds: 30 * 24 * 60 * 60,
+			showPace: true,
+		});
+	});
+
+	it("handles partial windows", () => {
+		const windows = parseOpenCodeGoUsage({
+			rolling: {
+				usagePercent: 10,
+				resetInSec: 15000,
+				percentRemaining: 90,
+				resetTimeIso: "2026-05-18T21:00:00Z",
+			},
+		});
+
+		expect(windows).toHaveLength(1);
+		expect(windows[0].label).toBe("5h Rolling");
+	});
+
+	it("returns empty for no data", () => {
+		const windows = parseOpenCodeGoUsage({});
+		expect(windows).toHaveLength(0);
+	});
 });

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -2,435 +2,560 @@ import type { QuotaWindow } from "../types/quotas.js";
 import { safePercent } from "../utils/quotas-severity.js";
 
 function parseDateish(value: unknown): Date {
-  if (typeof value === "number") {
-    const ms = value > 10 ** 11 ? value : value * 1000;
-    return new Date(ms);
-  }
-  if (typeof value === "string") return new Date(value);
-  return new Date(0);
+	if (typeof value === "number") {
+		const ms = value > 10 ** 11 ? value : value * 1000;
+		return new Date(ms);
+	}
+	if (typeof value === "string") return new Date(value);
+	return new Date(0);
 }
 
 function monthWindowSeconds(resetAt: Date): number {
-  const approxStart = new Date(resetAt);
-  approxStart.setMonth(approxStart.getMonth() - 1);
-  return Math.max(1, Math.round((resetAt.getTime() - approxStart.getTime()) / 1000));
+	const approxStart = new Date(resetAt);
+	approxStart.setMonth(approxStart.getMonth() - 1);
+	return Math.max(
+		1,
+		Math.round((resetAt.getTime() - approxStart.getTime()) / 1000),
+	);
 }
 
 export function parseAnthropicUsage(data: any): QuotaWindow[] {
-  const windows: QuotaWindow[] = [];
+	const windows: QuotaWindow[] = [];
 
-  if (data?.five_hour) {
-    windows.push({
-      provider: "anthropic",
-      label: "5h",
-      usedPercent: Number(data.five_hour.utilization ?? 0),
-      resetsAt: parseDateish(data.five_hour.resets_at),
-      windowSeconds: 5 * 60 * 60,
-      usedValue: Number(data.five_hour.utilization ?? 0),
-      limitValue: 100,
-      showPace: false,
-      nextLabel: "Resets",
-    });
-  }
+	if (data?.five_hour) {
+		windows.push({
+			provider: "anthropic",
+			label: "5h",
+			usedPercent: Number(data.five_hour.utilization ?? 0),
+			resetsAt: parseDateish(data.five_hour.resets_at),
+			windowSeconds: 5 * 60 * 60,
+			usedValue: Number(data.five_hour.utilization ?? 0),
+			limitValue: 100,
+			showPace: false,
+			nextLabel: "Resets",
+		});
+	}
 
-  if (data?.seven_day) {
-    windows.push({
-      provider: "anthropic",
-      label: "7d",
-      usedPercent: Number(data.seven_day.utilization ?? 0),
-      resetsAt: parseDateish(data.seven_day.resets_at),
-      windowSeconds: 7 * 24 * 60 * 60,
-      usedValue: Number(data.seven_day.utilization ?? 0),
-      limitValue: 100,
-      showPace: false,
-      nextLabel: "Resets",
-    });
-  }
+	if (data?.seven_day) {
+		windows.push({
+			provider: "anthropic",
+			label: "7d",
+			usedPercent: Number(data.seven_day.utilization ?? 0),
+			resetsAt: parseDateish(data.seven_day.resets_at),
+			windowSeconds: 7 * 24 * 60 * 60,
+			usedValue: Number(data.seven_day.utilization ?? 0),
+			limitValue: 100,
+			showPace: false,
+			nextLabel: "Resets",
+		});
+	}
 
-  // Per-model 7d windows
-  const modelWindows: Array<[string, string]> = [
-    ["seven_day_sonnet", "7d Sonnet"],
-    ["seven_day_omelette", "7d Opus"],
-    ["seven_day_opus", "7d Opus (legacy)"],
-  ];
-  for (const [key, label] of modelWindows) {
-    const entry = data?.[key];
-    if (entry && typeof entry === "object" && entry.utilization != null) {
-      windows.push({
-        provider: "anthropic",
-        label,
-        usedPercent: Number(entry.utilization),
-        resetsAt: parseDateish(entry.resets_at),
-        windowSeconds: 7 * 24 * 60 * 60,
-        usedValue: Number(entry.utilization),
-        limitValue: 100,
-        showPace: false,
-        nextLabel: "Resets",
-      });
-    }
-  }
+	// Per-model 7d windows
+	const modelWindows: Array<[string, string]> = [
+		["seven_day_sonnet", "7d Sonnet"],
+		["seven_day_omelette", "7d Opus"],
+		["seven_day_opus", "7d Opus (legacy)"],
+	];
+	for (const [key, label] of modelWindows) {
+		const entry = data?.[key];
+		if (entry && typeof entry === "object" && entry.utilization != null) {
+			windows.push({
+				provider: "anthropic",
+				label,
+				usedPercent: Number(entry.utilization),
+				resetsAt: parseDateish(entry.resets_at),
+				windowSeconds: 7 * 24 * 60 * 60,
+				usedValue: Number(entry.utilization),
+				limitValue: 100,
+				showPace: false,
+				nextLabel: "Resets",
+			});
+		}
+	}
 
-  // Extra usage (overage budget)
-  const extra = data?.extra_usage;
-  if (extra && extra.is_enabled && extra.monthly_limit > 0) {
-    const limitDollars = extra.monthly_limit / 100;
-    const usedDollars = (extra.used_credits ?? 0) / 100;
-    const currency = extra.currency ?? "USD";
-    windows.push({
-      provider: "anthropic",
-      label: `Extra (${currency})`,
-      usedPercent: Number(extra.utilization ?? safePercent(usedDollars, limitDollars)),
-      resetsAt: new Date(new Date().getFullYear(), new Date().getMonth() + 1, 1),
-      windowSeconds: 30 * 24 * 60 * 60,
-      usedValue: usedDollars,
-      limitValue: limitDollars,
-      isCurrency: true,
-      showPace: true,
-      paceScale: 1,
-      nextLabel: "Resets",
-    });
-  }
+	// Extra usage (overage budget)
+	const extra = data?.extra_usage;
+	if (extra && extra.is_enabled && extra.monthly_limit > 0) {
+		const limitDollars = extra.monthly_limit / 100;
+		const usedDollars = (extra.used_credits ?? 0) / 100;
+		const currency = extra.currency ?? "USD";
+		windows.push({
+			provider: "anthropic",
+			label: `Extra (${currency})`,
+			usedPercent: Number(
+				extra.utilization ?? safePercent(usedDollars, limitDollars),
+			),
+			resetsAt: new Date(
+				new Date().getFullYear(),
+				new Date().getMonth() + 1,
+				1,
+			),
+			windowSeconds: 30 * 24 * 60 * 60,
+			usedValue: usedDollars,
+			limitValue: limitDollars,
+			isCurrency: true,
+			showPace: true,
+			paceScale: 1,
+			nextLabel: "Resets",
+		});
+	}
 
-  return windows;
+	return windows;
 }
 
 function percentLeftToUsedPercent(limit: any): number {
-  if (limit?.percent_left != null) return Math.max(0, 100 - Number(limit.percent_left));
-  if (limit?.remaining_percent != null) return Math.max(0, 100 - Number(limit.remaining_percent));
-  if (limit?.used_percent != null) return Number(limit.used_percent);
-  return 0;
+	if (limit?.percent_left != null)
+		return Math.max(0, 100 - Number(limit.percent_left));
+	if (limit?.remaining_percent != null)
+		return Math.max(0, 100 - Number(limit.remaining_percent));
+	if (limit?.used_percent != null) return Number(limit.used_percent);
+	return 0;
 }
 
 export function parseCodexUsage(data: any): QuotaWindow[] {
-  const rateLimit = data?.rate_limit ?? data?.rate_limits ?? {};
-  const primary = rateLimit.primary_window ?? rateLimit.primary ?? rateLimit.five_hour_limit ?? rateLimit.five_hour;
-  const secondary = rateLimit.secondary_window ?? rateLimit.secondary ?? rateLimit.weekly_limit ?? rateLimit.weekly;
+	const rateLimit = data?.rate_limit ?? data?.rate_limits ?? {};
+	const primary =
+		rateLimit.primary_window ??
+		rateLimit.primary ??
+		rateLimit.five_hour_limit ??
+		rateLimit.five_hour;
+	const secondary =
+		rateLimit.secondary_window ??
+		rateLimit.secondary ??
+		rateLimit.weekly_limit ??
+		rateLimit.weekly;
 
-  const windows: QuotaWindow[] = [];
+	const windows: QuotaWindow[] = [];
 
-  if (primary) {
-    windows.push({
-      provider: "openai-codex",
-      label: "5h",
-      usedPercent: percentLeftToUsedPercent(primary),
-      resetsAt: parseDateish(primary.reset_at ?? primary.reset_time_ms),
-      windowSeconds: Number(primary.limit_window_seconds ?? 5 * 60 * 60),
-      usedValue: percentLeftToUsedPercent(primary),
-      limitValue: 100,
-      showPace: false,
-      nextLabel: "Resets",
-    });
-  }
+	if (primary) {
+		windows.push({
+			provider: "openai-codex",
+			label: "5h",
+			usedPercent: percentLeftToUsedPercent(primary),
+			resetsAt: parseDateish(primary.reset_at ?? primary.reset_time_ms),
+			windowSeconds: Number(primary.limit_window_seconds ?? 5 * 60 * 60),
+			usedValue: percentLeftToUsedPercent(primary),
+			limitValue: 100,
+			showPace: false,
+			nextLabel: "Resets",
+		});
+	}
 
-  if (secondary) {
-    windows.push({
-      provider: "openai-codex",
-      label: "7d",
-      usedPercent: percentLeftToUsedPercent(secondary),
-      resetsAt: parseDateish(secondary.reset_at ?? secondary.reset_time_ms),
-      windowSeconds: Number(secondary.limit_window_seconds ?? 7 * 24 * 60 * 60),
-      usedValue: percentLeftToUsedPercent(secondary),
-      limitValue: 100,
-      showPace: false,
-      nextLabel: "Resets",
-    });
-  }
+	if (secondary) {
+		windows.push({
+			provider: "openai-codex",
+			label: "7d",
+			usedPercent: percentLeftToUsedPercent(secondary),
+			resetsAt: parseDateish(secondary.reset_at ?? secondary.reset_time_ms),
+			windowSeconds: Number(secondary.limit_window_seconds ?? 7 * 24 * 60 * 60),
+			usedValue: percentLeftToUsedPercent(secondary),
+			limitValue: 100,
+			showPace: false,
+			nextLabel: "Resets",
+		});
+	}
 
-  // Credits balance
-  const credits = data?.credits;
-  if (credits && credits.has_credits && credits.balance != null) {
-    const balance = Number(credits.balance);
-    windows.push({
-      provider: "openai-codex",
-      label: "Credits",
-      usedPercent: 0,
-      resetsAt: new Date(0),
-      windowSeconds: 0,
-      usedValue: balance,
-      limitValue: balance,
-      isCurrency: true,
-      showPace: false,
-      nextLabel: credits.approx_local_messages
-        ? `~${credits.approx_local_messages} local msgs`
-        : undefined,
-    });
-  }
+	// Credits balance
+	const credits = data?.credits;
+	if (credits && credits.has_credits && credits.balance != null) {
+		const balance = Number(credits.balance);
+		windows.push({
+			provider: "openai-codex",
+			label: "Credits",
+			usedPercent: 0,
+			resetsAt: new Date(0),
+			windowSeconds: 0,
+			usedValue: balance,
+			limitValue: balance,
+			isCurrency: true,
+			showPace: false,
+			nextLabel: credits.approx_local_messages
+				? `~${credits.approx_local_messages} local msgs`
+				: undefined,
+		});
+	}
 
-  // Spend control
-  const spendControl = data?.spend_control;
-  if (spendControl) {
-    const reached = !!spendControl.reached;
-    windows.push({
-      provider: "openai-codex",
-      label: "Spend cap",
-      usedPercent: reached ? 100 : 0,
-      resetsAt: new Date(0),
-      windowSeconds: 0,
-      usedValue: reached ? 1 : 0,
-      limitValue: 1,
-      limited: reached,
-      showPace: false,
-      nextLabel: reached ? "Reached" : "OK",
-    });
-  }
+	// Spend control
+	const spendControl = data?.spend_control;
+	if (spendControl) {
+		const reached = !!spendControl.reached;
+		windows.push({
+			provider: "openai-codex",
+			label: "Spend cap",
+			usedPercent: reached ? 100 : 0,
+			resetsAt: new Date(0),
+			windowSeconds: 0,
+			usedValue: reached ? 1 : 0,
+			limitValue: 1,
+			limited: reached,
+			showPace: false,
+			nextLabel: reached ? "Reached" : "OK",
+		});
+	}
 
-  return windows;
+	return windows;
 }
 
 export function parseGitHubCopilotUsage(data: any): QuotaWindow[] {
-  const windows: QuotaWindow[] = [];
+	const windows: QuotaWindow[] = [];
 
-  const resetAt = parseDateish(data?.quota_reset_date ?? data?.quota_reset_date_utc ?? data?.limited_user_reset_date);
-  const periodSeconds = monthWindowSeconds(resetAt);
+	const resetAt = parseDateish(
+		data?.quota_reset_date ??
+			data?.quota_reset_date_utc ??
+			data?.limited_user_reset_date,
+	);
+	const periodSeconds = monthWindowSeconds(resetAt);
 
-  const snapshots = data?.quota_snapshots;
-  if (snapshots && typeof snapshots === "object") {
-    const mappings: Array<[string, string]> = [
-      ["premium_interactions", "Premium / month"],
-      ["chat", "Chat / month"],
-      ["completions", "Completions / month"],
-    ];
+	const snapshots = data?.quota_snapshots;
+	if (snapshots && typeof snapshots === "object") {
+		const mappings: Array<[string, string]> = [
+			["premium_interactions", "Premium / month"],
+			["chat", "Chat / month"],
+			["completions", "Completions / month"],
+		];
 
-    for (const [key, label] of mappings) {
-      const snap = snapshots[key];
-      if (!snap || snap.unlimited) continue;
-      const entitlement = Number(snap.entitlement ?? 0);
-      const remaining = Number(snap.remaining ?? snap.quota_remaining ?? 0);
-      if (entitlement <= 0) continue;
-      const overageCount = Number(snap.overage_count ?? 0);
-      const overagePermitted = !!snap.overage_permitted;
-      windows.push({
-        provider: "github-copilot",
-        label,
-        usedPercent: safePercent(entitlement - remaining, entitlement),
-        resetsAt: resetAt,
-        windowSeconds: periodSeconds,
-        usedValue: entitlement - remaining,
-        limitValue: entitlement,
-        showPace: true,
-        nextLabel: "Resets",
-        nextAmount: overageCount > 0
-          ? `+${overageCount} overage`
-          : overagePermitted
-            ? "overage allowed"
-            : undefined,
-      });
-    }
-    return windows;
-  }
+		for (const [key, label] of mappings) {
+			const snap = snapshots[key];
+			if (!snap || snap.unlimited) continue;
+			const entitlement = Number(snap.entitlement ?? 0);
+			const remaining = Number(snap.remaining ?? snap.quota_remaining ?? 0);
+			if (entitlement <= 0) continue;
+			const overageCount = Number(snap.overage_count ?? 0);
+			const overagePermitted = !!snap.overage_permitted;
+			windows.push({
+				provider: "github-copilot",
+				label,
+				usedPercent: safePercent(entitlement - remaining, entitlement),
+				resetsAt: resetAt,
+				windowSeconds: periodSeconds,
+				usedValue: entitlement - remaining,
+				limitValue: entitlement,
+				showPace: true,
+				nextLabel: "Resets",
+				nextAmount:
+					overageCount > 0
+						? `+${overageCount} overage`
+						: overagePermitted
+							? "overage allowed"
+							: undefined,
+			});
+		}
+		return windows;
+	}
 
-  if (data?.monthly_quotas && data?.limited_user_quotas) {
-    for (const [key, label] of [
-      ["chat", "Chat / month"],
-      ["completions", "Completions / month"],
-    ] as const) {
-      const limitValue = Number(data.monthly_quotas[key] ?? 0);
-      const remaining = Number(data.limited_user_quotas[key] ?? 0);
-      if (limitValue <= 0) continue;
-      windows.push({
-        provider: "github-copilot",
-        label,
-        usedPercent: safePercent(limitValue - remaining, limitValue),
-        resetsAt: resetAt,
-        windowSeconds: periodSeconds,
-        usedValue: limitValue - remaining,
-        limitValue,
-        showPace: true,
-        nextLabel: "Resets",
-      });
-    }
-  }
+	if (data?.monthly_quotas && data?.limited_user_quotas) {
+		for (const [key, label] of [
+			["chat", "Chat / month"],
+			["completions", "Completions / month"],
+		] as const) {
+			const limitValue = Number(data.monthly_quotas[key] ?? 0);
+			const remaining = Number(data.limited_user_quotas[key] ?? 0);
+			if (limitValue <= 0) continue;
+			windows.push({
+				provider: "github-copilot",
+				label,
+				usedPercent: safePercent(limitValue - remaining, limitValue),
+				resetsAt: resetAt,
+				windowSeconds: periodSeconds,
+				usedValue: limitValue - remaining,
+				limitValue,
+				showPace: true,
+				nextLabel: "Resets",
+			});
+		}
+	}
 
-  return windows;
+	return windows;
 }
 
 // Helper functions for OpenRouter date calculations (UTC-based)
 function calculateNextMidnightUTC(): Date {
-  const now = new Date();
-  const midnight = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0));
-  return midnight;
+	const now = new Date();
+	const midnight = new Date(
+		Date.UTC(
+			now.getUTCFullYear(),
+			now.getUTCMonth(),
+			now.getUTCDate() + 1,
+			0,
+			0,
+			0,
+		),
+	);
+	return midnight;
 }
 
 function calculateNextMondayUTC(): Date {
-  const now = new Date();
-  const day = now.getUTCDay(); // 0 = Sunday, 1 = Monday, etc.
-  const daysUntilMonday = day === 0 ? 1 : (8 - day); // Days until next Monday
-  const monday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + daysUntilMonday, 0, 0, 0));
-  return monday;
+	const now = new Date();
+	const day = now.getUTCDay(); // 0 = Sunday, 1 = Monday, etc.
+	const daysUntilMonday = day === 0 ? 1 : 8 - day; // Days until next Monday
+	const monday = new Date(
+		Date.UTC(
+			now.getUTCFullYear(),
+			now.getUTCMonth(),
+			now.getUTCDate() + daysUntilMonday,
+			0,
+			0,
+			0,
+		),
+	);
+	return monday;
 }
 
 function calculateNextMonthStartUTC(): Date {
-  const now = new Date();
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
+	const now = new Date();
+	return new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0),
+	);
 }
 
 export function parseOpenRouterUsage(data: any): QuotaWindow[] {
-  const windows: QuotaWindow[] = [];
-  const keyData = data?.data;
+	const windows: QuotaWindow[] = [];
+	const keyData = data?.data;
 
-  if (!keyData) return windows;
+	if (!keyData) return windows;
 
-  const limit = keyData.limit;
-  const limitRemaining = keyData.limit_remaining;
-  const usageDaily = keyData.usage_daily ?? 0;
-  const usageWeekly = keyData.usage_weekly ?? 0;
-  const usageMonthly = keyData.usage_monthly ?? 0;
+	const limit = keyData.limit;
+	const limitRemaining = keyData.limit_remaining;
+	const usageDaily = keyData.usage_daily ?? 0;
+	const usageWeekly = keyData.usage_weekly ?? 0;
+	const usageMonthly = keyData.usage_monthly ?? 0;
 
-  // Monthly budget window (if limit is set)
-  if (limit != null && limit > 0) {
-    const usedPercent = safePercent(usageMonthly, limit);
-    windows.push({
-      provider: "openrouter",
-      label: "Monthly Budget",
-      usedPercent,
-      resetsAt: calculateNextMonthStartUTC(),
-      windowSeconds: 30 * 24 * 60 * 60,
-      usedValue: usageMonthly,
-      limitValue: limit,
-      isCurrency: true,
-      showPace: true,
-      paceScale: 1,
-      nextLabel: "Resets",
-    });
-  } else if (limitRemaining != null && limitRemaining >= 0) {
-    // Unlimited key with remaining tracked
-    windows.push({
-      provider: "openrouter",
-      label: "Credits Remaining",
-      usedPercent: 0,
-      resetsAt: new Date(0),
-      windowSeconds: 0,
-      usedValue: limitRemaining,
-      limitValue: limitRemaining,
-      isCurrency: true,
-      showPace: false,
-      nextLabel: undefined,
-    });
-  }
+	// Monthly budget window (if limit is set)
+	if (limit != null && limit > 0) {
+		const usedPercent = safePercent(usageMonthly, limit);
+		windows.push({
+			provider: "openrouter",
+			label: "Monthly Budget",
+			usedPercent,
+			resetsAt: calculateNextMonthStartUTC(),
+			windowSeconds: 30 * 24 * 60 * 60,
+			usedValue: usageMonthly,
+			limitValue: limit,
+			isCurrency: true,
+			showPace: true,
+			paceScale: 1,
+			nextLabel: "Resets",
+		});
+	} else if (limitRemaining != null && limitRemaining >= 0) {
+		// Unlimited key with remaining tracked
+		windows.push({
+			provider: "openrouter",
+			label: "Credits Remaining",
+			usedPercent: 0,
+			resetsAt: new Date(0),
+			windowSeconds: 0,
+			usedValue: limitRemaining,
+			limitValue: limitRemaining,
+			isCurrency: true,
+			showPace: false,
+			nextLabel: undefined,
+		});
+	}
 
-  // Daily usage window (tracking only)
-  windows.push({
-    provider: "openrouter",
-    label: "Daily",
-    usedPercent: 0,
-    resetsAt: calculateNextMidnightUTC(),
-    windowSeconds: 24 * 60 * 60,
-    usedValue: usageDaily,
-    limitValue: 0,
-    isCurrency: true,
-    showPace: false,
-    nextLabel: "UTC",
-  });
+	// Daily usage window (tracking only)
+	windows.push({
+		provider: "openrouter",
+		label: "Daily",
+		usedPercent: 0,
+		resetsAt: calculateNextMidnightUTC(),
+		windowSeconds: 24 * 60 * 60,
+		usedValue: usageDaily,
+		limitValue: 0,
+		isCurrency: true,
+		showPace: false,
+		nextLabel: "UTC",
+	});
 
-  // Weekly usage window (tracking only)
-  windows.push({
-    provider: "openrouter",
-    label: "Weekly",
-    usedPercent: 0,
-    resetsAt: calculateNextMondayUTC(),
-    windowSeconds: 7 * 24 * 60 * 60,
-    usedValue: usageWeekly,
-    limitValue: 0,
-    isCurrency: true,
-    showPace: false,
-    nextLabel: "Week",
-  });
+	// Weekly usage window (tracking only)
+	windows.push({
+		provider: "openrouter",
+		label: "Weekly",
+		usedPercent: 0,
+		resetsAt: calculateNextMondayUTC(),
+		windowSeconds: 7 * 24 * 60 * 60,
+		usedValue: usageWeekly,
+		limitValue: 0,
+		isCurrency: true,
+		showPace: false,
+		nextLabel: "Week",
+	});
 
-  // Monthly usage window (tracking only)
-  windows.push({
-    provider: "openrouter",
-    label: "Monthly",
-    usedPercent: 0,
-    resetsAt: calculateNextMonthStartUTC(),
-    windowSeconds: 30 * 24 * 60 * 60,
-    usedValue: usageMonthly,
-    limitValue: 0,
-    isCurrency: true,
-    showPace: false,
-    nextLabel: "Month",
-  });
+	// Monthly usage window (tracking only)
+	windows.push({
+		provider: "openrouter",
+		label: "Monthly",
+		usedPercent: 0,
+		resetsAt: calculateNextMonthStartUTC(),
+		windowSeconds: 30 * 24 * 60 * 60,
+		usedValue: usageMonthly,
+		limitValue: 0,
+		isCurrency: true,
+		showPace: false,
+		nextLabel: "Month",
+	});
 
-  return windows;
+	return windows;
 }
 
 /** Parse currency strings like "$24.00" to a number */
 function parseCurrency(value: string): number {
-  const n = Number(value.replace(/[^0-9.-]/g, ""));
-  return Number.isFinite(n) ? n : 0;
+	const n = Number(value.replace(/[^0-9.-]/g, ""));
+	return Number.isFinite(n) ? n : 0;
 }
 
 export function parseSyntheticUsage(data: any): QuotaWindow[] {
-  const windows: QuotaWindow[] = [];
+	const windows: QuotaWindow[] = [];
 
-  // Weekly token/credit limit (primary window for paid plans)
-  if (data?.weeklyTokenLimit) {
-    const { weeklyTokenLimit } = data.weeklyTokenLimit;
-    const limitValue = parseCurrency(data.weeklyTokenLimit.maxCredits);
-    const remainingValue = parseCurrency(data.weeklyTokenLimit.remainingCredits);
-    windows.push({
-      provider: "synthetic",
-      label: "Credits / week",
-      usedPercent: Math.max(0, Math.min(100, 100 - data.weeklyTokenLimit.percentRemaining)),
-      resetsAt: parseDateish(data.weeklyTokenLimit.nextRegenAt),
-      windowSeconds: 24 * 60 * 60,
-      usedValue: limitValue - remainingValue,
-      limitValue,
-      isCurrency: true,
-      showPace: true,
-      paceScale: 1 / 7,
-      nextAmount: `+${data.weeklyTokenLimit.nextRegenCredits}`,
-      nextLabel: "Next regen",
-    });
-  }
+	// Weekly token/credit limit (primary window for paid plans)
+	if (data?.weeklyTokenLimit) {
+		const { weeklyTokenLimit } = data.weeklyTokenLimit;
+		const limitValue = parseCurrency(data.weeklyTokenLimit.maxCredits);
+		const remainingValue = parseCurrency(
+			data.weeklyTokenLimit.remainingCredits,
+		);
+		windows.push({
+			provider: "synthetic",
+			label: "Credits / week",
+			usedPercent: Math.max(
+				0,
+				Math.min(100, 100 - data.weeklyTokenLimit.percentRemaining),
+			),
+			resetsAt: parseDateish(data.weeklyTokenLimit.nextRegenAt),
+			windowSeconds: 24 * 60 * 60,
+			usedValue: limitValue - remainingValue,
+			limitValue,
+			isCurrency: true,
+			showPace: true,
+			paceScale: 1 / 7,
+			nextAmount: `+${data.weeklyTokenLimit.nextRegenCredits}`,
+			nextLabel: "Next regen",
+		});
+	}
 
-  // Rolling 5-hour request limit
-  if (data?.rollingFiveHourLimit && data.rollingFiveHourLimit.max > 0) {
-    const used = data.rollingFiveHourLimit.max - data.rollingFiveHourLimit.remaining;
-    windows.push({
-      provider: "synthetic",
-      label: "Requests / 5h",
-      usedPercent: safePercent(used, data.rollingFiveHourLimit.max),
-      resetsAt: parseDateish(data.rollingFiveHourLimit.nextTickAt),
-      windowSeconds: 5 * 60 * 60,
-      usedValue: Math.round(used),
-      limitValue: data.rollingFiveHourLimit.max,
-      showPace: false,
-      limited: data.rollingFiveHourLimit.limited,
-      nextLabel: data.rollingFiveHourLimit.limited ? "Limited" : "Resets",
-    });
-  }
+	// Rolling 5-hour request limit
+	if (data?.rollingFiveHourLimit && data.rollingFiveHourLimit.max > 0) {
+		const used =
+			data.rollingFiveHourLimit.max - data.rollingFiveHourLimit.remaining;
+		windows.push({
+			provider: "synthetic",
+			label: "Requests / 5h",
+			usedPercent: safePercent(used, data.rollingFiveHourLimit.max),
+			resetsAt: parseDateish(data.rollingFiveHourLimit.nextTickAt),
+			windowSeconds: 5 * 60 * 60,
+			usedValue: Math.round(used),
+			limitValue: data.rollingFiveHourLimit.max,
+			showPace: false,
+			limited: data.rollingFiveHourLimit.limited,
+			nextLabel: data.rollingFiveHourLimit.limited ? "Limited" : "Resets",
+		});
+	}
 
-  // Search hourly (only if limit > 0)
-  if (data?.search?.hourly?.limit && data.search.hourly.limit > 0) {
-    windows.push({
-      provider: "synthetic",
-      label: "Search / hour",
-      usedPercent: safePercent(data.search.hourly.requests, data.search.hourly.limit),
-      resetsAt: parseDateish(data.search.hourly.renewsAt),
-      windowSeconds: 60 * 60,
-      usedValue: data.search.hourly.requests,
-      limitValue: data.search.hourly.limit,
-      showPace: true,
-      paceScale: 1,
-      nextLabel: "Resets",
-    });
-  }
+	// Search hourly (only if limit > 0)
+	if (data?.search?.hourly?.limit && data.search.hourly.limit > 0) {
+		windows.push({
+			provider: "synthetic",
+			label: "Search / hour",
+			usedPercent: safePercent(
+				data.search.hourly.requests,
+				data.search.hourly.limit,
+			),
+			resetsAt: parseDateish(data.search.hourly.renewsAt),
+			windowSeconds: 60 * 60,
+			usedValue: data.search.hourly.requests,
+			limitValue: data.search.hourly.limit,
+			showPace: true,
+			paceScale: 1,
+			nextLabel: "Resets",
+		});
+	}
 
-  // Free tool calls (only if limit > 0)
-  if (data?.freeToolCalls?.limit && data.freeToolCalls.limit > 0) {
-    windows.push({
-      provider: "synthetic",
-      label: "Free Tool Calls / day",
-      usedPercent: safePercent(data.freeToolCalls.requests, data.freeToolCalls.limit),
-      resetsAt: parseDateish(data.freeToolCalls.renewsAt),
-      windowSeconds: 24 * 60 * 60,
-      usedValue: data.freeToolCalls.requests,
-      limitValue: data.freeToolCalls.limit,
-      showPace: true,
-      paceScale: 1,
-      nextLabel: "Resets",
-    });
-  }
+	// Free tool calls (only if limit > 0)
+	if (data?.freeToolCalls?.limit && data.freeToolCalls.limit > 0) {
+		windows.push({
+			provider: "synthetic",
+			label: "Free Tool Calls / day",
+			usedPercent: safePercent(
+				data.freeToolCalls.requests,
+				data.freeToolCalls.limit,
+			),
+			resetsAt: parseDateish(data.freeToolCalls.renewsAt),
+			windowSeconds: 24 * 60 * 60,
+			usedValue: data.freeToolCalls.requests,
+			limitValue: data.freeToolCalls.limit,
+			showPace: true,
+			paceScale: 1,
+			nextLabel: "Resets",
+		});
+	}
 
-  return windows;
+	return windows;
+}
+
+export function parseOpenCodeGoUsage(data: {
+	rolling?: {
+		usagePercent: number;
+		resetInSec: number;
+		percentRemaining: number;
+		resetTimeIso: string;
+	};
+	weekly?: {
+		usagePercent: number;
+		resetInSec: number;
+		percentRemaining: number;
+		resetTimeIso: string;
+	};
+	monthly?: {
+		usagePercent: number;
+		resetInSec: number;
+		percentRemaining: number;
+		resetTimeIso: string;
+	};
+}): QuotaWindow[] {
+	const windows: QuotaWindow[] = [];
+
+	if (data.rolling) {
+		windows.push({
+			provider: "opencode-go",
+			label: "5h Rolling",
+			usedPercent: data.rolling.usagePercent,
+			resetsAt: new Date(data.rolling.resetTimeIso),
+			windowSeconds: 5 * 60 * 60,
+			usedValue: data.rolling.usagePercent,
+			limitValue: 100,
+			showPace: false,
+			nextLabel: "Resets",
+		});
+	}
+
+	if (data.weekly) {
+		windows.push({
+			provider: "opencode-go",
+			label: "Weekly",
+			usedPercent: data.weekly.usagePercent,
+			resetsAt: new Date(data.weekly.resetTimeIso),
+			windowSeconds: 7 * 24 * 60 * 60,
+			usedValue: data.weekly.usagePercent,
+			limitValue: 100,
+			showPace: true,
+			paceScale: 1 / 7,
+			nextLabel: "Resets",
+		});
+	}
+
+	if (data.monthly) {
+		windows.push({
+			provider: "opencode-go",
+			label: "Monthly",
+			usedPercent: data.monthly.usagePercent,
+			resetsAt: new Date(data.monthly.resetTimeIso),
+			windowSeconds: 30 * 24 * 60 * 60,
+			usedValue: data.monthly.usagePercent,
+			limitValue: 100,
+			showPace: true,
+			paceScale: 1,
+			nextLabel: "Resets",
+		});
+	}
+
+	return windows;
 }

--- a/src/types/quotas.ts
+++ b/src/types/quotas.ts
@@ -1,33 +1,37 @@
 export type SupportedQuotaProvider =
-  | "anthropic"
-  | "openai-codex"
-  | "github-copilot"
-  | "openrouter"
-  | "synthetic";
+	| "anthropic"
+	| "openai-codex"
+	| "github-copilot"
+	| "openrouter"
+	| "synthetic"
+	| "opencode-go";
 
 export type QuotasErrorKind =
-  | "cancelled"
-  | "timeout"
-  | "config"
-  | "http"
-  | "network";
+	| "cancelled"
+	| "timeout"
+	| "config"
+	| "http"
+	| "network";
 
 export type QuotasResult =
-  | { success: true; data: { windows: QuotaWindow[]; provider: SupportedQuotaProvider } }
-  | { success: false; error: { message: string; kind: QuotasErrorKind } };
+	| {
+			success: true;
+			data: { windows: QuotaWindow[]; provider: SupportedQuotaProvider };
+	  }
+	| { success: false; error: { message: string; kind: QuotasErrorKind } };
 
 export interface QuotaWindow {
-  provider: SupportedQuotaProvider;
-  label: string;
-  usedPercent: number;
-  resetsAt: Date;
-  windowSeconds: number;
-  usedValue: number;
-  limitValue: number;
-  isCurrency?: boolean;
-  showPace?: boolean;
-  paceScale?: number;
-  limited?: boolean;
-  nextAmount?: string;
-  nextLabel?: string;
+	provider: SupportedQuotaProvider;
+	label: string;
+	usedPercent: number;
+	resetsAt: Date;
+	windowSeconds: number;
+	usedValue: number;
+	limitValue: number;
+	isCurrency?: boolean;
+	showPace?: boolean;
+	paceScale?: number;
+	limited?: boolean;
+	nextAmount?: string;
+	nextLabel?: string;
 }

--- a/src/utils/quotas-severity.ts
+++ b/src/utils/quotas-severity.ts
@@ -4,158 +4,170 @@ export type { QuotaWindow } from "../types/quotas.js";
 export type RiskSeverity = "none" | "warning" | "high" | "critical";
 
 export interface WindowProjection {
-  pacePercent: number | null;
-  progress: number | null;
-  projectedPercent: number;
-  usedPercent: number;
+	pacePercent: number | null;
+	progress: number | null;
+	projectedPercent: number;
+	usedPercent: number;
 }
 
 export interface RiskAssessment extends WindowProjection {
-  usedFloorPercent: number | null;
-  warnProjectedPercent: number | null;
-  highProjectedPercent: number | null;
-  criticalProjectedPercent: number | null;
-  severity: RiskSeverity;
+	usedFloorPercent: number | null;
+	warnProjectedPercent: number | null;
+	highProjectedPercent: number | null;
+	criticalProjectedPercent: number | null;
+	severity: RiskSeverity;
 }
 
 const MIN_PACE_PERCENT = 5;
 const THRESHOLDS = {
-  usedFloor: { start: 33, end: 8 },
-  warnProjected: { start: 260, end: 120 },
-  highProjected: { start: 320, end: 145 },
-  criticalProjected: { start: 400, end: 170 },
+	usedFloor: { start: 33, end: 8 },
+	warnProjected: { start: 260, end: 120 },
+	highProjected: { start: 320, end: 145 },
+	criticalProjected: { start: 400, end: 170 },
 };
 
 function interpolate(start: number, end: number, progress: number): number {
-  const clampedProgress = Math.max(0, Math.min(1, progress));
-  return start + (end - start) * clampedProgress;
+	const clampedProgress = Math.max(0, Math.min(1, progress));
+	return start + (end - start) * clampedProgress;
 }
 
 export function safePercent(used: number, limit: number): number {
-  if (!Number.isFinite(used) || !Number.isFinite(limit) || limit <= 0) return 0;
-  return Math.max(0, Math.min(100, (used / limit) * 100));
+	if (!Number.isFinite(used) || !Number.isFinite(limit) || limit <= 0) return 0;
+	return Math.max(0, Math.min(100, (used / limit) * 100));
 }
 
 export function getPacePercent(window: QuotaWindow): number | null {
-  const totalMs = window.windowSeconds * 1000;
-  if (totalMs <= 0) return null;
-  const remainingMs = window.resetsAt.getTime() - Date.now();
-  const elapsedMs = totalMs - remainingMs;
-  return Math.max(0, Math.min(100, (elapsedMs / totalMs) * 100));
+	const totalMs = window.windowSeconds * 1000;
+	if (totalMs <= 0) return null;
+	const remainingMs = window.resetsAt.getTime() - Date.now();
+	const elapsedMs = totalMs - remainingMs;
+	return Math.max(0, Math.min(100, (elapsedMs / totalMs) * 100));
 }
 
 export function getProjectedPercent(
-  usedPercent: number,
-  pacePercent: number | null,
+	usedPercent: number,
+	pacePercent: number | null,
 ): number {
-  if (pacePercent === null) return usedPercent;
-  const effectivePace = Math.max(MIN_PACE_PERCENT, pacePercent);
-  return Math.max(0, (usedPercent / effectivePace) * 100);
+	if (pacePercent === null) return usedPercent;
+	const effectivePace = Math.max(MIN_PACE_PERCENT, pacePercent);
+	return Math.max(0, (usedPercent / effectivePace) * 100);
 }
 
-function absoluteUsageSeverity(window: QuotaWindow, percent: number): RiskSeverity {
-  if (window.limited || percent >= 100) return "critical";
-  if (percent >= 90) return "high";
-  if (percent >= 80) return "warning";
-  return "none";
+function absoluteUsageSeverity(
+	window: QuotaWindow,
+	percent: number,
+): RiskSeverity {
+	if (window.limited || percent >= 100) return "critical";
+	if (percent >= 90) return "high";
+	if (percent >= 80) return "warning";
+	return "none";
 }
 
 function maxSeverity(a: RiskSeverity, b: RiskSeverity): RiskSeverity {
-  const order: RiskSeverity[] = ["none", "warning", "high", "critical"];
-  return order[Math.max(order.indexOf(a), order.indexOf(b))] ?? "none";
+	const order: RiskSeverity[] = ["none", "warning", "high", "critical"];
+	return order[Math.max(order.indexOf(a), order.indexOf(b))] ?? "none";
 }
 
 export function assessWindow(window: QuotaWindow): RiskAssessment {
-  const rawPace = window.showPace ? getPacePercent(window) : null;
-  const pacePercent =
-    rawPace !== null ? rawPace * (window.paceScale ?? 1) : null;
-  const projectedPercent = getProjectedPercent(window.usedPercent, pacePercent);
-  const absoluteSeverity = absoluteUsageSeverity(window, window.usedPercent);
+	const rawPace = window.showPace ? getPacePercent(window) : null;
+	const pacePercent =
+		rawPace !== null ? rawPace * (window.paceScale ?? 1) : null;
+	const projectedPercent = getProjectedPercent(window.usedPercent, pacePercent);
+	const absoluteSeverity = absoluteUsageSeverity(window, window.usedPercent);
 
-  let progress: number | null = null;
-  if (pacePercent !== null) progress = pacePercent / 100;
+	let progress: number | null = null;
+	if (pacePercent !== null) progress = pacePercent / 100;
 
-  const base: WindowProjection = {
-    pacePercent,
-    progress,
-    projectedPercent,
-    usedPercent: window.usedPercent,
-  };
+	const base: WindowProjection = {
+		pacePercent,
+		progress,
+		projectedPercent,
+		usedPercent: window.usedPercent,
+	};
 
-  if (progress === null) {
-    const severity = absoluteUsageSeverity(window, projectedPercent);
+	if (progress === null) {
+		const severity = absoluteUsageSeverity(window, projectedPercent);
 
-    return {
-      ...base,
-      usedFloorPercent: null,
-      warnProjectedPercent: 80,
-      highProjectedPercent: 90,
-      criticalProjectedPercent: 100,
-      severity,
-    };
-  }
+		return {
+			...base,
+			usedFloorPercent: null,
+			warnProjectedPercent: 80,
+			highProjectedPercent: 90,
+			criticalProjectedPercent: 100,
+			severity,
+		};
+	}
 
-  const usedFloorPercent = interpolate(
-    THRESHOLDS.usedFloor.start,
-    THRESHOLDS.usedFloor.end,
-    progress,
-  );
-  const warnProjectedPercent = interpolate(
-    THRESHOLDS.warnProjected.start,
-    THRESHOLDS.warnProjected.end,
-    progress,
-  );
-  const highProjectedPercent = interpolate(
-    THRESHOLDS.highProjected.start,
-    THRESHOLDS.highProjected.end,
-    progress,
-  );
-  const criticalProjectedPercent = interpolate(
-    THRESHOLDS.criticalProjected.start,
-    THRESHOLDS.criticalProjected.end,
-    progress,
-  );
+	const usedFloorPercent = interpolate(
+		THRESHOLDS.usedFloor.start,
+		THRESHOLDS.usedFloor.end,
+		progress,
+	);
+	const warnProjectedPercent = interpolate(
+		THRESHOLDS.warnProjected.start,
+		THRESHOLDS.warnProjected.end,
+		progress,
+	);
+	const highProjectedPercent = interpolate(
+		THRESHOLDS.highProjected.start,
+		THRESHOLDS.highProjected.end,
+		progress,
+	);
+	const criticalProjectedPercent = interpolate(
+		THRESHOLDS.criticalProjected.start,
+		THRESHOLDS.criticalProjected.end,
+		progress,
+	);
 
-  let severity: RiskSeverity = "none";
-  if (window.limited) {
-    severity = "critical";
-  } else if (window.usedPercent >= usedFloorPercent) {
-    if (projectedPercent >= criticalProjectedPercent) severity = "critical";
-    else if (projectedPercent >= highProjectedPercent) severity = "high";
-    else if (projectedPercent >= warnProjectedPercent) severity = "warning";
-  }
+	let severity: RiskSeverity = "none";
+	if (window.limited) {
+		severity = "critical";
+	} else if (window.usedPercent >= usedFloorPercent) {
+		if (projectedPercent >= criticalProjectedPercent) severity = "critical";
+		else if (projectedPercent >= highProjectedPercent) severity = "high";
+		else if (projectedPercent >= warnProjectedPercent) severity = "warning";
+	}
 
-  return {
-    ...base,
-    usedFloorPercent,
-    warnProjectedPercent,
-    highProjectedPercent,
-    criticalProjectedPercent,
-    severity: maxSeverity(severity, absoluteSeverity),
-  };
+	return {
+		...base,
+		usedFloorPercent,
+		warnProjectedPercent,
+		highProjectedPercent,
+		criticalProjectedPercent,
+		severity: maxSeverity(severity, absoluteSeverity),
+	};
 }
 
 export function formatTimeRemaining(date: Date): string {
-  const ms = date.getTime() - Date.now();
-  if (ms <= 0) return "now";
-  const totalMins = Math.ceil(ms / (1000 * 60));
-  const hours = Math.floor(totalMins / 60);
-  const mins = totalMins % 60;
-  if (hours >= 1) return mins > 0 ? `${hours}h${mins}m` : `${hours}h`;
-  const totalSecs = Math.ceil(ms / 1000);
-  return totalMins >= 1 ? `${totalMins}m` : `${totalSecs}s`;
+	const ms = date.getTime() - Date.now();
+	if (ms <= 0) return "now";
+	const totalMins = Math.ceil(ms / (1000 * 60));
+	const totalHours = Math.floor(totalMins / 60);
+	const days = Math.floor(totalHours / 24);
+	const hours = totalHours % 24;
+	const mins = totalMins % 60;
+
+	if (days >= 1) {
+		const parts: string[] = [`${days}d`];
+		if (hours > 0) parts.push(`${hours}h`);
+		if (mins > 0) parts.push(`${mins}m`);
+		return parts.join("");
+	}
+	if (hours >= 1) return mins > 0 ? `${hours}h${mins}m` : `${hours}h`;
+	const totalSecs = Math.ceil(ms / 1000);
+	return totalMins >= 1 ? `${totalMins}m` : `${totalSecs}s`;
 }
 
 export function getSeverityColor(
-  severity: RiskSeverity,
+	severity: RiskSeverity,
 ): "success" | "warning" | "error" {
-  switch (severity) {
-    case "critical":
-    case "high":
-      return "error";
-    case "warning":
-      return "warning";
-    default:
-      return "success";
-  }
+	switch (severity) {
+		case "critical":
+		case "high":
+			return "error";
+		case "warning":
+			return "warning";
+		default:
+			return "success";
+	}
 }


### PR DESCRIPTION
feat: token usage tracking + OpenCode Go provider

- `/tokens` command: cross-session token/cost aggregation from JSONL files
- OpenCode Go provider: dashboard scraper for rolling/weekly/monthly usage
- Status bar shows Go usage when using `opencode-go*` models
- Fix: quota warning labels use `PROVIDER_LABELS` instead of hardcoded "Anthropic"
- `formatTimeRemaining` shows days when >=24h (`649h30m` -> `27d1h30m`)
- Config: `OPENCODE_GO_WORKSPACE_ID` + `OPENCODE_GO_AUTH_COOKIE` env or config file