### PR TITLE
feat: add Z.ai (GLM Coding Plan) provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @latentminds/pi-quotas
 
-Quota monitoring for Pi. Shows remaining usage and rate limits for Anthropic, OpenAI Codex, GitHub Copilot, OpenRouter, and Synthetic — directly in your Pi session.
+Quota monitoring for Pi. Shows remaining usage and rate limits for Anthropic, OpenAI Codex, GitHub Copilot, OpenRouter, Synthetic, and Z.ai — directly in your Pi session.
 
 ## Screenshots
 
@@ -42,6 +42,7 @@ pi -e npm:@latentminds/pi-quotas
 | `/github:quotas`     | GitHub Copilot quotas only                 |
 | `/openrouter:quotas` | OpenRouter quotas only                     |
 | `/synthetic:quotas`  | Synthetic quotas only                      |
+| `/zai:quotas`        | Z.ai quotas only                           |
 | `/quotas:settings`   | Toggle individual features on or off       |
 
 
@@ -64,7 +65,7 @@ Automatic notifications when projected usage is on track to exceed limits before
 Use `/quotas:settings` to enable or disable:
 
 - Combined `/quotas` command
-- Per-provider commands (`/anthropic:quotas`, `/codex:quotas`, `/github:quotas`, `/openrouter:quotas`, `/synthetic:quotas`)
+- Per-provider commands (`/anthropic:quotas`, `/codex:quotas`, `/github:quotas`, `/openrouter:quotas`, `/synthetic:quotas`, `/zai:quotas`)
 - Footer status widget
 - Quota warning notifications
 - **Defer to Synthetic** — when both pi-quotas and [pi-synthetic](https://www.npmjs.com/package/@aliou/pi-synthetic) are loaded, pi-quotas hides its own Synthetic footer to avoid showing duplicate quota information. Enabled by default; disable if you prefer to see both footers.
@@ -81,6 +82,7 @@ Settings can be saved globally (`~/.pi/agent/extensions/quotas.json`) or per-pro
 | GitHub Copilot | Premium/chat/completions per month                             | Remaining/entitlement counts with overage indicators                                                |
 | OpenRouter     | Monthly budget, daily/weekly/monthly usage                     | USD spending tracking with cents precision; optional per-key budget limits; UTC-based period resets |
 | Synthetic      | Subscription, search/hour, free tools, weekly tokens, 5h limit | Request counts and token budgets; rolling five-hour rate limit; weekly token regen                  |
+| Z.ai           | 5h, 7d, monthly web searches                                  | Token utilisation percentages (rolling 5h/7d windows); monthly web-search count limit               |
 
 
 ## Credentials
@@ -92,6 +94,7 @@ pi-quotas reads existing Pi auth entries from `~/.pi/agent/auth.json`:
 - `github-copilot` — GitHub Copilot OAuth token (falls back to `gh auth token` if needed)
 - `openrouter` — OpenRouter API key (Bearer token)
 - `synthetic` — Synthetic API key (set the `SYNTHETIC_API_KEY` environment variable)
+- `zai` — Z.ai (Zhipu AI / GLM Coding Plan) API key
 
 No additional setup is required - if Pi can use the provider, pi-quotas can check its quotas. For Synthetic, export `SYNTHETIC_API_KEY` in your shell or Pi environment.
 

--- a/src/extensions/command-quotas/provider-commands.test.ts
+++ b/src/extensions/command-quotas/provider-commands.test.ts
@@ -40,4 +40,13 @@ describe("getProviderCommandInfo", () => {
       title: "OpenRouter Quotas",
     });
   });
+
+  it("maps zai to zai:quotas", () => {
+    const info = getProviderCommandInfo("zai");
+    expect(info).toMatchObject<Partial<ProviderCommandInfo>>({
+      provider: "zai",
+      commandName: "zai:quotas",
+      title: "Z.ai Quotas",
+    });
+  });
 });

--- a/src/extensions/command-quotas/provider-commands.ts
+++ b/src/extensions/command-quotas/provider-commands.ts
@@ -40,5 +40,11 @@ export function getProviderCommandInfo(
         commandName: "synthetic:quotas",
         title: "Synthetic Quotas",
       };
+    case "zai":
+      return {
+        provider,
+        commandName: "zai:quotas",
+        title: "Z.ai Quotas",
+      };
   }
 }

--- a/src/lib/quotas.ts
+++ b/src/lib/quotas.ts
@@ -8,6 +8,7 @@ export const SUPPORTED_PROVIDERS: SupportedQuotaProvider[] = [
   "github-copilot",
   "openrouter",
   "synthetic",
+  "zai",
 ];
 
 export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
@@ -16,6 +17,7 @@ export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
   "github-copilot": "GitHub Copilot",
   openrouter: "OpenRouter",
   synthetic: "Synthetic",
+  zai: "Z.ai",
 };
 
 const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
@@ -24,6 +26,7 @@ const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
   "github-copilot": 5 * 60_000,
   openrouter: 60_000,
   synthetic: 60_000,
+  zai: 60_000,
 };
 
 type CacheEntry = {

--- a/src/providers/fetch.ts
+++ b/src/providers/fetch.ts
@@ -10,6 +10,7 @@ import {
   parseGitHubCopilotUsage,
   parseOpenRouterUsage,
   parseSyntheticUsage,
+  parseZaiUsage,
 } from "./providers.js";
 
 const FETCH_TIMEOUT_MS = 15_000;
@@ -325,10 +326,37 @@ export async function fetchSyntheticQuotas(
   return success("synthetic", parseSyntheticUsage(result.data));
 }
 
+export async function fetchZaiQuotasWithToken(
+  apiKey: string | undefined,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  if (!apiKey) return failure("No Z.ai API key found", "config");
+  const result = await fetchJson(
+    "https://api.z.ai/api/monitor/usage/quota/limit",
+    {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    },
+    signal,
+  );
+  if (!result.ok) return failure(result.message, result.kind);
+  return success("zai", parseZaiUsage(result.data));
+}
+
+export async function fetchZaiQuotas(
+  authStorage: AuthStorage,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  return fetchZaiQuotasWithToken(await providerAccessToken(authStorage, "zai"), signal);
+}
+
 export const PROVIDER_FETCHERS = {
   anthropic: fetchAnthropicQuotas,
   "openai-codex": fetchCodexQuotas,
   "github-copilot": fetchGitHubCopilotQuotas,
   openrouter: fetchOpenRouterQuotas,
   synthetic: fetchSyntheticQuotas,
+  zai: fetchZaiQuotas,
 } as const;

--- a/src/providers/parse.test.ts
+++ b/src/providers/parse.test.ts
@@ -4,6 +4,7 @@ import { parseCodexUsage } from "./providers.js";
 import { parseGitHubCopilotUsage } from "./providers.js";
 import { parseOpenRouterUsage } from "./providers.js";
 import { parseSyntheticUsage } from "./providers.js";
+import { parseZaiUsage } from "./providers.js";
 
 describe("parseAnthropicUsage", () => {
   it("maps oauth usage response into quota windows", () => {
@@ -539,5 +540,89 @@ describe("parseSyntheticUsage", () => {
   it("returns empty array when no data", () => {
     const windows = parseSyntheticUsage({});
     expect(windows).toHaveLength(0);
+  });
+});
+
+describe("parseZaiUsage", () => {
+  it("maps token windows (5h/7d) and the monthly web-search count", () => {
+    const windows = parseZaiUsage({
+      data: {
+        level: "lite",
+        limits: [
+          {
+            type: "TIME_LIMIT",
+            unit: 5,
+            number: 1,
+            usage: 100,
+            currentValue: 25,
+            remaining: 75,
+            percentage: 25,
+            nextResetTime: 1785048370995,
+            usageDetails: [
+              { modelCode: "search-prime", usage: 20 },
+              { modelCode: "web-reader", usage: 5 },
+            ],
+          },
+          {
+            type: "TOKENS_LIMIT",
+            unit: 3,
+            number: 5,
+            percentage: 8,
+            nextResetTime: 1782932874304,
+          },
+          {
+            type: "TOKENS_LIMIT",
+            unit: 6,
+            number: 1,
+            percentage: 52,
+            nextResetTime: 1783061170994,
+          },
+        ],
+      },
+    });
+
+    // Shortest window first: 5h → 7d → month
+    expect(windows).toHaveLength(3);
+    expect(windows[0]).toMatchObject({
+      provider: "zai",
+      label: "5h",
+      usedPercent: 8,
+      windowSeconds: 5 * 60 * 60,
+      usedValue: 8,
+      limitValue: 100,
+    });
+    expect(windows[1]).toMatchObject({
+      provider: "zai",
+      label: "7d",
+      usedPercent: 52,
+      windowSeconds: 7 * 24 * 60 * 60,
+    });
+    expect(windows[2]).toMatchObject({
+      provider: "zai",
+      label: "Web / month",
+      usedPercent: 25,
+      usedValue: 25,
+      limitValue: 100,
+      windowSeconds: 30 * 24 * 60 * 60,
+    });
+  });
+
+  it("skips the monthly window when the entitlement is zero", () => {
+    const windows = parseZaiUsage({
+      data: {
+        limits: [
+          { type: "TIME_LIMIT", unit: 5, number: 1, usage: 0, currentValue: 0, nextResetTime: 1785048370995 },
+          { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 0, nextResetTime: 1782932874304 },
+        ],
+      },
+    });
+    expect(windows).toHaveLength(1);
+    expect(windows[0].label).toBe("5h");
+  });
+
+  it("returns empty array when there are no limits", () => {
+    expect(parseZaiUsage({})).toHaveLength(0);
+    expect(parseZaiUsage({ data: {} })).toHaveLength(0);
+    expect(parseZaiUsage({ data: { limits: [] } })).toHaveLength(0);
   });
 });

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -434,3 +434,92 @@ export function parseSyntheticUsage(data: any): QuotaWindow[] {
 
   return windows;
 }
+
+// Z.ai (Zhipu AI) GLM Coding Plan quotas.
+//
+// The quota endpoint returns { data: { limits: [...], level } }. Each entry in
+// `limits` is either a TOKENS_LIMIT (token utilisation, reported as a bare
+// `percentage` with no absolute used/limit counts) or a TIME_LIMIT (a monthly
+// count window such as web searches, which does carry real used/limit counts).
+//
+// The window length is encoded as (unit, number). Observed values:
+//   unit 3 = HOUR  (e.g. the rolling 5-hour session window)
+//   unit 6 = WEEK  (e.g. the rolling 7-day weekly window)
+//   unit 5 = MONTH (TIME_LIMIT only, the monthly count window)
+// Reset times are epoch milliseconds.
+export function parseZaiUsage(data: any): QuotaWindow[] {
+  const collected: QuotaWindow[] = [];
+
+  const limits: any[] = data?.data?.limits ?? data?.limits ?? [];
+  if (!Array.isArray(limits)) return collected;
+
+  for (const entry of limits) {
+    if (!entry || typeof entry !== "object") continue;
+
+    // Token windows only expose a percentage, so — like Anthropic/Codex — we
+    // report usedValue as the percentage against a nominal limit of 100.
+    if (entry.type === "TOKENS_LIMIT") {
+      const unit = entry.unit;
+      const count = Number(entry.number ?? 1) || 1;
+      let label: string;
+      let windowSeconds: number;
+
+      switch (unit) {
+        case 3: // HOUR
+          label = `${count}h`;
+          windowSeconds = count * 60 * 60;
+          break;
+        case 4: // DAY (defensive — not observed, but handled)
+          label = `${count}d`;
+          windowSeconds = count * 24 * 60 * 60;
+          break;
+        case 6: // WEEK
+          label = `${count * 7}d`;
+          windowSeconds = count * 7 * 24 * 60 * 60;
+          break;
+        default:
+          // Unknown unit — still surface it so usage is never silently hidden.
+          label = "Tokens";
+          windowSeconds = 0;
+          break;
+      }
+
+      collected.push({
+        provider: "zai",
+        label,
+        usedPercent: Number(entry.percentage ?? 0),
+        resetsAt: parseDateish(entry.nextResetTime),
+        windowSeconds,
+        usedValue: Number(entry.percentage ?? 0),
+        limitValue: 100,
+        showPace: false,
+        nextLabel: "Resets",
+      });
+      continue;
+    }
+
+    // Monthly web-search / tool-call count window. Here z.ai gives real
+    // counts: `usage` is the entitlement, `currentValue` is what's been used.
+    if (entry.type === "TIME_LIMIT") {
+      const limit = Number(entry.usage ?? 0);
+      const used = Number(entry.currentValue ?? 0);
+      if (limit <= 0) continue;
+
+      collected.push({
+        provider: "zai",
+        label: "Web / month",
+        usedPercent: safePercent(used, limit),
+        resetsAt: parseDateish(entry.nextResetTime),
+        windowSeconds: 30 * 24 * 60 * 60,
+        usedValue: used,
+        limitValue: limit,
+        showPace: false,
+        nextLabel: "Resets",
+      });
+    }
+  }
+
+  // Shortest window first (5h → 7d → month), matching Anthropic/Codex order.
+  collected.sort((a, b) => a.windowSeconds - b.windowSeconds);
+  return collected;
+}

--- a/src/types/quotas.ts
+++ b/src/types/quotas.ts
@@ -3,7 +3,8 @@ export type SupportedQuotaProvider =
   | "openai-codex"
   | "github-copilot"
   | "openrouter"
-  | "synthetic";
+  | "synthetic"
+  | "zai";
 
 export type QuotasErrorKind =
   | "cancelled"


### PR DESCRIPTION
## Summary

Adds **Z.ai / Zhipu AI GLM Coding Plan** as a first-class quota provider, so Pi sessions that use a `zai` model (e.g. `glm-5.2`) get the same treatment as the existing providers — the footer usage widget, the `/quotas` dashboard, `/zai:quotas`, and quota warnings.

This fills a gap: currently `isSupportedProvider("zai")` is `false`, so a `zai/*` model silently shows **no** quota in the footer.

## Windows surfaced

The GLM Coding Plan exposes three windows, and all three are shown:

| Window | Type | Reported as |
| --- | --- | --- |
| `5h` | rolling session token window (`TOKENS_LIMIT`) | utilisation % |
| `7d` | rolling weekly token window (`TOKENS_LIMIT`) | utilisation % |
| `Web / month` | monthly web-search / tool-call count (`TIME_LIMIT`) | used / limit |

Token windows only carry a `percentage` (no absolute used/limit counts), so — like Anthropic and Codex — they're reported as a percentage against a nominal limit of 100. The monthly `TIME_LIMIT` carries real `used`/`limit` counts, so those are shown directly.

## Auth

Read from the existing Pi `zai` auth entry via `authStorage.getApiKey("zai")` — **no new setup**. This mirrors how OpenRouter is handled (if Pi can use the provider, pi-quotas can check its quotas).

## Endpoint

```
GET https://api.z.ai/api/monitor/usage/quota/limit   (Authorization: Bearer <key>)
```

These are the same internal endpoints z.ai's own subscription UI calls. They are undocumented, but stable in practice — consistent with how the existing GitHub Copilot and OpenRouter providers already operate against reverse-engineered endpoints.

## Implementation

Follows the established provider pattern exactly:

- `src/types/quotas.ts` — `"zai"` added to `SupportedQuotaProvider`
- `src/lib/quotas.ts` — `SUPPORTED_PROVIDERS` / `PROVIDER_LABELS` / `PROVIDER_TTLS_MS`
- `src/providers/providers.ts` — `parseZaiUsage` (window length decoded from the `(unit, number)` pair: `3`=hour, `6`=week, `5`=month)
- `src/providers/fetch.ts` — `fetchZaiQuotas`(+`WithToken`) + `PROVIDER_FETCHERS`
- `src/extensions/command-quotas/provider-commands.ts` — `/zai:quotas` case
- `README.md` — provider table row, command, credentials

## Verification

- `npm run typecheck` — clean
- `npm test` — 66 tests pass (added parse + provider-command coverage)
- Parser validated against a **live** GLM Coding Plan response (`GLM Coding Lite` plan) — produces the expected `5h` / `7d` / `Web / month` windows with correct reset times.

Happy to adjust labels, window naming, or split into smaller commits if preferred.
