### PR TITLE
feat: add Ollama Cloud quota provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Ollama Cloud provider**: rolling 5-hour session and 7-day weekly usage windows from the undocumented `/api/usage` endpoint, with the `/ollama:quotas` command, dashboard, footer status, and quota warnings. Reads the `ollama-cloud` API key from `auth.json` (falls back to `OLLAMA_API_KEY`).
+
 ## [0.4.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @latentminds/pi-quotas
 
-Quota monitoring for Pi. Shows remaining usage and rate limits for Anthropic, OpenAI Codex, GitHub Copilot, OpenRouter, Synthetic, Z.ai, OpenCode Go, and Kimi Code — directly in your Pi session.
+Quota monitoring for Pi. Shows remaining usage and rate limits for Anthropic, OpenAI Codex, GitHub Copilot, OpenRouter, Synthetic, Z.ai, OpenCode Go, Kimi Code, and Ollama Cloud — directly in your Pi session.
 
 ## Screenshots
 
@@ -45,6 +45,7 @@ pi -e npm:@latentminds/pi-quotas
 | `/zai:quotas`        | Z.ai quotas only                           |
 | `/opencode-go:quotas`| OpenCode Go quotas only                    |
 | `/kimi:quotas`       | Kimi Code quotas only                      |
+| `/ollama:quotas`     | Ollama Cloud quotas only                   |
 | `/tokens`            | Cross-session token/cost usage            |
 | `/quotas:settings`   | Toggle individual features on or off       |
 
@@ -68,7 +69,7 @@ Automatic notifications when projected usage is on track to exceed limits before
 Use `/quotas:settings` to enable or disable:
 
 - Combined `/quotas` command
-- Per-provider commands (`/anthropic:quotas`, `/codex:quotas`, `/github:quotas`, `/openrouter:quotas`, `/synthetic:quotas`, `/zai:quotas`, `/opencode-go:quotas`, `/kimi:quotas`)
+- Per-provider commands (`/anthropic:quotas`, `/codex:quotas`, `/github:quotas`, `/openrouter:quotas`, `/synthetic:quotas`, `/zai:quotas`, `/opencode-go:quotas`, `/kimi:quotas`, `/ollama:quotas`)
 - Footer status widget
 - Quota warning notifications
 - **Defer to Synthetic** — when both pi-quotas and [pi-synthetic](https://www.npmjs.com/package/@aliou/pi-synthetic) are loaded, pi-quotas hides its own Synthetic footer to avoid showing duplicate quota information. Enabled by default; disable if you prefer to see both footers.
@@ -88,6 +89,7 @@ Settings can be saved globally (`~/.pi/agent/extensions/quotas.json`) or per-pro
 | Z.ai           | 5h, 7d, monthly web searches                                  | Token utilisation percentages (rolling 5h/7d windows); monthly web-search count limit               |
 | OpenCode Go    | Rolling 5h, weekly, monthly USD                              | USD spend tracking against tier limits; cross-session token/cost aggregation via the `/tokens` command |
 | Kimi Code      | Rolling 5h, weekly                                           | Coding Plan request allowances with reset times                                                        |
+| Ollama Cloud   | 5h, 7d                                                       | Rolling session (5h) and weekly (7d) usage fractions from the `/api/usage` endpoint                  |
 
 
 ## Credentials
@@ -102,6 +104,7 @@ pi-quotas reads existing Pi auth entries from `~/.pi/agent/auth.json`:
 - `zai` — Z.ai (Zhipu AI / GLM Coding Plan) API key
 - `opencode-go` — OpenCode Go workspace ID and auth cookie (set the `OPENCODE_GO_WORKSPACE_ID` and `OPENCODE_GO_AUTH_COOKIE` environment variables, or configure them in the OpenCode Go config file)
 - `kimi-coding` — Kimi Code OAuth access token
+- `ollama-cloud` — Ollama Cloud API key (also reads `OLLAMA_API_KEY` if set)
 
 No additional setup is required - if Pi can use the provider, pi-quotas can check its quotas. For Synthetic, export `SYNTHETIC_API_KEY` in your shell or Pi environment.
 

--- a/src/extensions/command-quotas/provider-commands.ts
+++ b/src/extensions/command-quotas/provider-commands.ts
@@ -58,5 +58,11 @@ export function getProviderCommandInfo(
         commandName: "kimi:quotas",
         title: "Kimi Code Quotas",
       };
+    case "ollama-cloud":
+      return {
+        provider,
+        commandName: "ollama:quotas",
+        title: "Ollama Cloud Quotas",
+      };
   }
 }

--- a/src/lib/quotas.ts
+++ b/src/lib/quotas.ts
@@ -11,6 +11,7 @@ export const SUPPORTED_PROVIDERS: SupportedQuotaProvider[] = [
   "zai",
   "opencode-go",
   "kimi-coding",
+  "ollama-cloud",
 ];
 
 export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
@@ -22,6 +23,7 @@ export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
   zai: "Z.ai",
   "opencode-go": "OpenCode Go",
   "kimi-coding": "Kimi Code",
+  "ollama-cloud": "Ollama Cloud",
 };
 
 const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
@@ -33,6 +35,7 @@ const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
   zai: 60_000,
   "opencode-go": 60_000,
   "kimi-coding": 60_000,
+  "ollama-cloud": 60_000,
 };
 
 type CacheEntry = {

--- a/src/providers/fetch.test.ts
+++ b/src/providers/fetch.test.ts
@@ -6,6 +6,7 @@ import {
   fetchGitHubCopilotQuotas,
   fetchGitHubCopilotQuotasWithToken,
   fetchKimiCodingQuotasWithToken,
+  fetchOllamaCloudQuotasWithToken,
   fetchOpenRouterQuotasWithToken,
 } from "./fetch.js";
 
@@ -317,5 +318,44 @@ describe("fetchOpenRouterQuotasWithToken", () => {
       expect(result.error.message).toBe("invalid x-api-key");
       expect(result.error.message).not.toContain("{");
     }
+  });
+});
+
+describe("fetchOllamaCloudQuotasWithToken", () => {
+  it("returns config error when token missing", async () => {
+    const result = await fetchOllamaCloudQuotasWithToken(undefined);
+    expect(result).toMatchObject({
+      success: false,
+      error: { kind: "config" },
+    });
+  });
+
+  it("fetches and parses Ollama Cloud usage", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          limits: {
+            session: { usage: 0.34, models: [] },
+            weekly: { usage: 0.45, models: [] },
+          },
+        }),
+        { status: 200 },
+      ),
+    ) as any;
+
+    const result = await fetchOllamaCloudQuotasWithToken("ollama-key");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.provider).toBe("ollama-cloud");
+      expect(result.data.windows).toHaveLength(2);
+    }
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://ollama.com/api/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ollama-key",
+        }),
+      }),
+    );
   });
 });

--- a/src/providers/fetch.ts
+++ b/src/providers/fetch.ts
@@ -9,6 +9,7 @@ import {
   parseCodexUsage,
   parseGitHubCopilotUsage,
   parseKimiCodingUsage,
+  parseOllamaCloudUsage,
   parseOpenRouterUsage,
   parseSyntheticUsage,
   parseZaiUsage,
@@ -500,6 +501,35 @@ export async function fetchZaiQuotas(
   return fetchZaiQuotasWithToken(await providerAccessToken(authStorage, "zai"), signal);
 }
 
+export async function fetchOllamaCloudQuotasWithToken(
+  apiKey: string | undefined,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  if (!apiKey) return failure("No Ollama Cloud API key found", "config");
+  const result = await fetchJson(
+    "https://ollama.com/api/usage",
+    {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    },
+    signal,
+  );
+  if (!result.ok) return failure(result.message, result.kind);
+  return success("ollama-cloud", parseOllamaCloudUsage(result.data));
+}
+
+export async function fetchOllamaCloudQuotas(
+  authStorage: AuthStorage,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  const apiKey =
+    (await providerAccessToken(authStorage, "ollama-cloud")) ??
+    process.env.OLLAMA_API_KEY;
+  return fetchOllamaCloudQuotasWithToken(apiKey, signal);
+}
+
 export const PROVIDER_FETCHERS = {
   anthropic: fetchAnthropicQuotas,
   "openai-codex": fetchCodexQuotas,
@@ -509,4 +539,5 @@ export const PROVIDER_FETCHERS = {
   zai: fetchZaiQuotas,
   "opencode-go": fetchOpenCodeGoQuotas,
   "kimi-coding": fetchKimiCodingQuotas,
+  "ollama-cloud": fetchOllamaCloudQuotas,
 } as const;

--- a/src/providers/parse.test.ts
+++ b/src/providers/parse.test.ts
@@ -3,6 +3,7 @@ import { parseAnthropicUsage } from "./providers.js";
 import { parseCodexUsage } from "./providers.js";
 import { parseGitHubCopilotUsage } from "./providers.js";
 import { parseKimiCodingUsage } from "./providers.js";
+import { parseOllamaCloudUsage } from "./providers.js";
 import { parseOpenRouterUsage } from "./providers.js";
 import { parseSyntheticUsage } from "./providers.js";
 import { parseZaiUsage } from "./providers.js";
@@ -858,5 +859,56 @@ describe("parseZaiUsage", () => {
     expect(parseZaiUsage({})).toHaveLength(0);
     expect(parseZaiUsage({ data: {} })).toHaveLength(0);
     expect(parseZaiUsage({ data: { limits: [] } })).toHaveLength(0);
+  });
+});
+
+describe("parseOllamaCloudUsage", () => {
+  it("maps session and weekly usage fractions into quota windows", () => {
+    const windows = parseOllamaCloudUsage({
+      limits: {
+        session: {
+          usage: 0.022,
+          models: [{ name: "deepseek-v4-pro:0813", request_count: 15 }],
+        },
+        weekly: {
+          usage: 0.004,
+          models: [{ name: "deepseek-v4-pro:0813", request_count: 15 }],
+        },
+      },
+      activity: { cost: "0.00000" },
+    });
+
+    expect(windows).toHaveLength(2);
+    expect(windows[0]).toMatchObject({
+      provider: "ollama-cloud",
+      label: "5h",
+      usedPercent: 2,
+      windowSeconds: 5 * 60 * 60,
+      usedValue: 2,
+      limitValue: 100,
+    });
+    expect(windows[1]).toMatchObject({
+      provider: "ollama-cloud",
+      label: "7d",
+      usedPercent: 0,
+      windowSeconds: 7 * 24 * 60 * 60,
+    });
+  });
+
+  it("clamps usage fractions above 1 to 100%", () => {
+    const windows = parseOllamaCloudUsage({
+      limits: {
+        session: { usage: 1.5, models: [] },
+        weekly: { usage: 0.5, models: [] },
+      },
+    });
+
+    expect(windows[0].usedPercent).toBe(100);
+    expect(windows[1].usedPercent).toBe(50);
+  });
+
+  it("returns empty array when limits are missing", () => {
+    expect(parseOllamaCloudUsage({})).toHaveLength(0);
+    expect(parseOllamaCloudUsage({ limits: {} })).toHaveLength(0);
   });
 });

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -749,3 +749,41 @@ export function parseZaiUsage(data: any): QuotaWindow[] {
   collected.sort((a, b) => a.windowSeconds - b.windowSeconds);
   return collected;
 }
+
+// Ollama Cloud subscription quotas. The undocumented /api/usage endpoint
+// exposes a rolling 5-hour session limit and a rolling 7-day weekly limit,
+// each reported as a 0-1 usage fraction (not tokens) plus per-model request
+// counts. Reset timestamps are not exposed, so windows carry no reset time.
+export function parseOllamaCloudUsage(data: any): QuotaWindow[] {
+  const windows: QuotaWindow[] = [];
+
+  const session = data?.limits?.session;
+  if (session && typeof session.usage === "number") {
+    windows.push({
+      provider: "ollama-cloud",
+      label: "5h",
+      usedPercent: Math.max(0, Math.min(100, Math.round(session.usage * 100))),
+      resetsAt: new Date(0),
+      windowSeconds: 5 * 60 * 60,
+      usedValue: Math.max(0, Math.min(100, Math.round(session.usage * 100))),
+      limitValue: 100,
+      showPace: false,
+    });
+  }
+
+  const weekly = data?.limits?.weekly;
+  if (weekly && typeof weekly.usage === "number") {
+    windows.push({
+      provider: "ollama-cloud",
+      label: "7d",
+      usedPercent: Math.max(0, Math.min(100, Math.round(weekly.usage * 100))),
+      resetsAt: new Date(0),
+      windowSeconds: 7 * 24 * 60 * 60,
+      usedValue: Math.max(0, Math.min(100, Math.round(weekly.usage * 100))),
+      limitValue: 100,
+      showPace: false,
+    });
+  }
+
+  return windows;
+}

--- a/src/types/quotas.ts
+++ b/src/types/quotas.ts
@@ -6,7 +6,8 @@ export type SupportedQuotaProvider =
   | "synthetic"
   | "zai"
   | "opencode-go"
-  | "kimi-coding";
+  | "kimi-coding"
+  | "ollama-cloud";
 
 export type QuotasErrorKind =
   | "cancelled"


### PR DESCRIPTION
## Summary

Adds **Ollama Cloud** as a supported quota provider, so users on `ollama-cloud` models see their rolling usage limits in the `/quotas` dashboard, the footer status widget, and quota warnings.

## What it does

- Reads the undocumented `https://ollama.com/api/usage` endpoint, which reports a rolling **5-hour session** limit and a rolling **7-day weekly** limit as 0–1 usage fractions (plus per-model request counts).
- Registers the `/ollama:quotas` command and includes the provider in the combined `/quotas` dashboard and footer usage status.
- Resolves the `ollama-cloud` API key from `auth.json` (the same credential `pi-ollama-cloud` uses), with an `OLLAMA_API_KEY` env fallback.

## Windows

| Label | Source | Notes |
|-------|--------|-------|
| `5h`  | `limits.session.usage` | rolling session limit |
| `7d`  | `limits.weekly.usage`  | rolling weekly limit |

The endpoint does not expose reset timestamps, so windows carry no reset countdown (matching how `pi-ollama-cloud`'s own status bar renders them).

## Changes

- `src/types/quotas.ts` — add `"ollama-cloud"` to `SupportedQuotaProvider`
- `src/providers/providers.ts` — `parseOllamaCloudUsage`
- `src/providers/fetch.ts` — `fetchOllamaCloudQuotas` / `fetchOllamaCloudQuotasWithToken`, registered in `PROVIDER_FETCHERS`
- `src/lib/quotas.ts` — provider label + TTL
- `src/extensions/command-quotas/provider-commands.ts` — `/ollama:quotas`
- `src/providers/parse.test.ts` / `fetch.test.ts` — unit tests
- `README.md` / `CHANGELOG.md` — docs

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (110 passed)
- Live smoke against the real `/api/usage` endpoint with a valid key ✅
