### PR TITLE
feat: hide inactive quota providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ pi -e npm:@latentminds/pi-quotas
 
 Run `/quotas` to open a bordered TUI view showing all providers side by side, with progress bars, used/remaining counts, and reset times. Press `r` to refresh, `q` or `Esc` to close.
 
+The combined dashboard hides providers with no configured subscription, credentials that cannot report subscription usage, and successful responses with no quota windows. Provider-specific commands remain available and show detailed authentication or API errors for troubleshooting.
+
 ### Footer status widget
 
 When your active model is from a supported provider, the Pi footer shows real-time quota headroom - updated every 60 seconds and on each turn. Colours shift from green → amber → red as usage climbs.

--- a/docs/plans/2026-08-27-hide-inactive-providers.md
+++ b/docs/plans/2026-08-27-hide-inactive-providers.md
@@ -1,0 +1,110 @@
+# Hide Inactive Providers Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Make the combined `/quotas` dashboard show only providers with active quota data or actionable runtime failures.
+
+**Architecture:** Add a pure dashboard visibility selector at the command boundary. Hide missing configuration, non-applicable credentials, and successful responses without windows; retain timeout, network, and HTTP failures because those may represent configured subscriptions that need attention. Provider-specific commands bypass the selector so they remain useful for diagnostics.
+
+**Tech Stack:** TypeScript, Pi extension API, Vitest, Pi TUI component tests, ESLint.
+
+---
+
+### Task 1: Define dashboard visibility rules
+
+**Files:**
+- Create: `src/extensions/command-quotas/visibility.test.ts`
+- Create: `src/extensions/command-quotas/visibility.ts`
+
+**Step 1: Write the failing tests**
+
+Assert that successful snapshots with windows remain visible; `config`, `not_applicable`, and successful empty snapshots are hidden; HTTP, network, timeout, and cancelled failures remain visible.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/extensions/command-quotas/visibility.test.ts`
+
+Expected: FAIL because the visibility module does not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement `filterDashboardSnapshots` as a pure filter over the shared snapshot shape.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/extensions/command-quotas/visibility.test.ts`
+
+Expected: PASS.
+
+### Task 2: Apply filtering only to the combined dashboard
+
+**Files:**
+- Modify: `src/extensions/command-quotas/command.ts`
+
+**Step 1: Add a failing wiring test**
+
+Extend the visibility tests or add a focused command test proving the combined loader passes results through `filterDashboardSnapshots`, while the provider-specific loader returns its diagnostic result unchanged.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/extensions/command-quotas/visibility.test.ts`
+
+Expected: FAIL until the combined command calls the selector.
+
+**Step 3: Write minimal implementation**
+
+Wrap only `fetchAllProviderQuotas` results with `filterDashboardSnapshots`. Leave `fetchProviderQuotas` calls untouched.
+
+**Step 4: Run focused tests**
+
+Run: `npx vitest run src/extensions/command-quotas/visibility.test.ts`
+
+Expected: PASS.
+
+### Task 3: Explain an empty active-subscription result
+
+**Files:**
+- Modify: `src/extensions/command-quotas/components/quotas-display.test.ts`
+- Modify: `src/extensions/command-quotas/components/quotas-display.ts`
+- Modify: `README.md`
+
+**Step 1: Write the failing component test**
+
+Assert that an empty loaded dashboard renders `No active quota subscriptions detected`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/extensions/command-quotas/components/quotas-display.test.ts`
+
+Expected: FAIL because the empty dashboard currently renders no body text.
+
+**Step 3: Implement and document**
+
+Render the dim empty-state message and document that `/quotas` suppresses providers without usable subscription quota data while provider commands retain diagnostics.
+
+**Step 4: Run focused tests**
+
+Run: `npx vitest run src/extensions/command-quotas/components/quotas-display.test.ts src/extensions/command-quotas/visibility.test.ts`
+
+Expected: PASS.
+
+### Task 4: Verify and commit
+
+**Files:**
+- Verify all modified files
+
+**Step 1: Run full verification**
+
+Run: `npm test && npm run typecheck && npm run lint`
+
+Expected: all tests pass and both static checks exit 0.
+
+**Step 2: Review the diff**
+
+Run: `git diff --check && git diff --stat && git status --short`
+
+Expected: no whitespace errors and only dashboard-visibility files plus this plan are changed.
+
+**Step 3: Commit**
+
+Run: `git add docs/plans/2026-08-27-hide-inactive-providers.md src README.md && git commit -m "feat: hide inactive quota providers"`

--- a/src/extensions/command-quotas/command.test.ts
+++ b/src/extensions/command-quotas/command.test.ts
@@ -1,0 +1,52 @@
+import { AuthStorage } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { registerQuotasCommands } from "./command.js";
+
+function registeredCommands() {
+  const commands = new Map<string, any>();
+  registerQuotasCommands({
+    registerCommand(name: string, command: any) {
+      commands.set(name, command);
+    },
+  } as any);
+  return commands;
+}
+
+function contextWithoutCredentials(notify: ReturnType<typeof vi.fn>) {
+  return {
+    modelRegistry: { authStorage: AuthStorage.inMemory({}) },
+    ui: {
+      custom: async () => undefined,
+      notify,
+    },
+  } as any;
+}
+
+describe("quota command visibility", () => {
+  it("hides unconfigured providers from the combined dashboard", async () => {
+    const commands = registeredCommands();
+    const notify = vi.fn();
+
+    await commands.get("quotas").handler(
+      "",
+      contextWithoutCredentials(notify),
+    );
+
+    expect(notify).toHaveBeenCalledWith("No quota data available", "info");
+  });
+
+  it("keeps provider-specific commands diagnostic", async () => {
+    const commands = registeredCommands();
+    const notify = vi.fn();
+
+    await commands.get("anthropic:quotas").handler(
+      "",
+      contextWithoutCredentials(notify),
+    );
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("No Anthropic OAuth token found"),
+      "info",
+    );
+  });
+});

--- a/src/extensions/command-quotas/command.ts
+++ b/src/extensions/command-quotas/command.ts
@@ -13,6 +13,7 @@ import {
 import type { QuotasResult, SupportedQuotaProvider } from "../../types/quotas.js";
 import { QuotasComponent } from "./components/quotas-display.js";
 import { getProviderCommandInfo } from "./provider-commands.js";
+import { filterDashboardSnapshots } from "./visibility.js";
 
 type Snapshot = { provider: SupportedQuotaProvider; result: QuotasResult };
 
@@ -96,7 +97,13 @@ export function registerQuotasCommands(pi: ExtensionAPI): void {
       }
       await openQuotaView(
         "Provider Quotas",
-        (force, signal) => fetchAllProviderQuotas(quotaAuthStorage(ctx.modelRegistry), { force, signal }),
+        async (force, signal) =>
+          filterDashboardSnapshots(
+            await fetchAllProviderQuotas(
+              quotaAuthStorage(ctx.modelRegistry),
+              { force, signal },
+            ),
+          ),
         ctx,
       );
     },

--- a/src/extensions/command-quotas/components/quotas-display.test.ts
+++ b/src/extensions/command-quotas/components/quotas-display.test.ts
@@ -38,6 +38,15 @@ describe("QuotasComponent", () => {
     expect(component.render(70).join("\n")).toContain(`pi-quotas v${pkg.version}`);
   });
 
+  it("explains when no active quota subscriptions are detected", () => {
+    const component = makeComponent();
+    component.setState({ type: "loaded", snapshots: [] });
+
+    expect(component.render(70).join("\n")).toContain(
+      "No active quota subscriptions detected",
+    );
+  });
+
   it("does not render an accent-colored pace marker inside filled warning bars", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-14T13:42:11Z"));

--- a/src/extensions/command-quotas/components/quotas-display.ts
+++ b/src/extensions/command-quotas/components/quotas-display.ts
@@ -125,6 +125,16 @@ export class QuotasComponent implements Component {
   }
 
   private renderLoaded(snapshots: Snapshot[], maxWidth: number): string[] {
+    if (snapshots.length === 0) {
+      return [
+        "",
+        truncateToWidth(
+          `  ${this.theme.fg("dim", "No active quota subscriptions detected")}`,
+          maxWidth,
+        ),
+      ];
+    }
+
     const lines: string[] = [""];
     for (const snapshot of snapshots) {
       lines.push(...this.renderProvider(snapshot, maxWidth));

--- a/src/extensions/command-quotas/visibility.test.ts
+++ b/src/extensions/command-quotas/visibility.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type {
+  QuotasErrorKind,
+  QuotasResult,
+  SupportedQuotaProvider,
+} from "../../types/quotas.js";
+import { filterDashboardSnapshots } from "./visibility.js";
+
+function success(
+  provider: SupportedQuotaProvider,
+  windowCount = 1,
+): QuotasResult {
+  return {
+    success: true,
+    data: {
+      provider,
+      windows: Array.from({ length: windowCount }, () => ({
+        provider,
+        label: "5h",
+        usedPercent: 10,
+        resetsAt: new Date("2026-08-27T12:00:00Z"),
+        windowSeconds: 5 * 60 * 60,
+        usedValue: 10,
+        limitValue: 100,
+      })),
+    },
+  };
+}
+
+function failure(message: string, kind: QuotasErrorKind): QuotasResult {
+  return { success: false, error: { message, kind } };
+}
+
+describe("filterDashboardSnapshots", () => {
+  it("keeps providers that returned quota windows", () => {
+    const snapshots = [
+      { provider: "openai-codex" as const, result: success("openai-codex") },
+      { provider: "kimi-coding" as const, result: success("kimi-coding", 2) },
+    ];
+
+    expect(filterDashboardSnapshots(snapshots)).toEqual(snapshots);
+  });
+
+  it("hides unconfigured, non-applicable, and empty providers", () => {
+    const snapshots = [
+      {
+        provider: "anthropic" as const,
+        result: failure("No token", "config"),
+      },
+      {
+        provider: "synthetic" as const,
+        result: failure("Direct key", "not_applicable"),
+      },
+      {
+        provider: "openrouter" as const,
+        result: success("openrouter", 0),
+      },
+    ];
+
+    expect(filterDashboardSnapshots(snapshots)).toEqual([]);
+  });
+
+  it.each<QuotasErrorKind>(["http", "network", "timeout", "cancelled"])(
+    "keeps configured provider failures of kind %s",
+    (kind) => {
+      const snapshot = {
+        provider: "openai-codex" as const,
+        result: failure("temporary failure", kind),
+      };
+
+      expect(filterDashboardSnapshots([snapshot])).toEqual([snapshot]);
+    },
+  );
+});

--- a/src/extensions/command-quotas/visibility.ts
+++ b/src/extensions/command-quotas/visibility.ts
@@ -1,0 +1,18 @@
+import type {
+  QuotasResult,
+  SupportedQuotaProvider,
+} from "../../types/quotas.js";
+
+export type QuotaSnapshot = {
+  provider: SupportedQuotaProvider;
+  result: QuotasResult;
+};
+
+export function filterDashboardSnapshots<T extends QuotaSnapshot>(
+  snapshots: T[],
+): T[] {
+  return snapshots.filter(({ result }) => {
+    if (result.success) return result.data.windows.length > 0;
+    return !["config", "not_applicable"].includes(result.error.kind);
+  });
+}


### PR DESCRIPTION
## Summary

- hide unconfigured, non-applicable, and empty providers from the combined /quotas dashboard
- keep HTTP, network, timeout, and cancellation failures visible
- preserve detailed diagnostics in provider-specific commands and add an explicit empty state

## Behavior

The filter is applied only to the combined dashboard. Commands such as /anthropic:quotas continue to report missing credentials and API errors directly.

## Test plan

- npm test (114 tests)
- npm run typecheck
- npm run lint
- git diff/check and committed-tree checks