### PR TITLE
feat(usage-status): compact footer formatting and concise reset display

### DIFF
--- a/src/extensions/usage-status/format-status.test.ts
+++ b/src/extensions/usage-status/format-status.test.ts
@@ -43,7 +43,7 @@ describe("formatWindowStatus", () => {
       limitValue: 100,
     };
     const result = formatWindowStatus(theme, w);
-    expect(result).toContain("91% left");
+    expect(result).toContain("91%");
     expect(result).toContain("[success]");
   });
 
@@ -91,7 +91,7 @@ describe("formatWindowStatus", () => {
     const result = formatWindowStatus(theme, w);
     // label should be colored with error (high maps to error)
     expect(result).toContain("[error]7d:");
-    expect(result).toContain("15% left");
+    expect(result).toContain("15%");
   });
 
   it("keeps label dim when severity is none", () => {
@@ -133,8 +133,8 @@ describe("formatWindowStatus", () => {
 
       const result = formatStatus({ ui: { theme } } as any, [status]);
 
-      expect(result).toContain("(↺in 2h 19m)");
-      expect(result).not.toContain("(↺in 3h)");
+      expect(result).toContain("(2h 19m)");
+      expect(result).not.toContain("(3h)");
     }
   });
 
@@ -242,7 +242,7 @@ describe("formatWindowStatus", () => {
       ],
     );
 
-    expect(result).toContain("(↺now)");
-    expect(result).not.toContain("(↺in now)");
+    expect(result).toContain("(now)");
+    expect(result).not.toContain("(in now)");
   });
 });

--- a/src/extensions/usage-status/format-status.test.ts
+++ b/src/extensions/usage-status/format-status.test.ts
@@ -138,6 +138,26 @@ describe("formatWindowStatus", () => {
     }
   });
 
+  it("preserves reset display for tracking-only windows with usedValue", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-06T05:28:37Z"));
+
+    const status = toWindowStatus({
+      provider: "openrouter",
+      label: "Daily",
+      usedPercent: 0,
+      resetsAt: new Date("2026-05-06T07:47:37Z"),
+      windowSeconds: 24 * 60 * 60,
+      usedValue: 12.5,
+      limitValue: 0,
+      isCurrency: true,
+    });
+
+    const result = formatStatus({ ui: { theme } } as any, [status]);
+    expect(result).toContain("$12.50 used");
+    expect(result).toContain("(2h 19m)");
+  });
+
   it("omits footer reset tags for windows without a real reset time", () => {
     const result = formatStatus(
       { ui: { theme } } as any,

--- a/src/extensions/usage-status/format-status.ts
+++ b/src/extensions/usage-status/format-status.ts
@@ -99,7 +99,7 @@ export function formatWindowStatus(theme: ThemeLike, w: WindowStatus): string {
     valueText = theme.fg(color, `${remaining}/${w.limitValue}`);
   } else {
     const remaining = Math.max(0, Math.min(100, Math.round(100 - w.usedPercent)));
-    valueText = theme.fg(color, `${remaining}% left`);
+    valueText = theme.fg(color, `${remaining}%`);
   }
 
   const limitTag = w.limited ? theme.fg("error", " !") : "";

--- a/src/extensions/usage-status/index.ts
+++ b/src/extensions/usage-status/index.ts
@@ -47,7 +47,7 @@ function getContextProvider(ctx: ExtensionContext | undefined): string | undefin
 
 function formatFooterResetTime(resetsAt: string): string {
   const remaining = formatTimeRemaining(new Date(resetsAt));
-  return remaining === "now" ? "now" : `in ${remaining}`;
+  return `(${remaining})`;
 }
 
 export function formatStatus(ctx: Pick<ExtensionContext, "ui">, windows: WindowStatus[]): string {
@@ -55,10 +55,12 @@ export function formatStatus(ctx: Pick<ExtensionContext, "ui">, windows: WindowS
   return windows
     .map((w) => {
       const core = formatWindowStatus(theme, w);
-      const reset = w.resetsAt ? theme.fg("dim", ` (↺${formatFooterResetTime(w.resetsAt)})`) : "";
+      const shouldShowReset = w.resetsAt && (w.usedPercent > 0 || w.severity !== "none");
+      const resetTime = shouldShowReset ? formatFooterResetTime(w.resetsAt!) : "";
+      const reset = resetTime ? theme.fg("dim", ` ${resetTime}`) : "";
       return `${core}${reset}`;
     })
-    .join(" ");
+    .join(theme.fg("dim", " · "));
 }
 
 const ANTHROPIC_SUBSCRIPTION_WINDOW_LABELS = new Set([

--- a/src/extensions/usage-status/index.ts
+++ b/src/extensions/usage-status/index.ts
@@ -55,7 +55,8 @@ export function formatStatus(ctx: Pick<ExtensionContext, "ui">, windows: WindowS
   return windows
     .map((w) => {
       const core = formatWindowStatus(theme, w);
-      const shouldShowReset = w.resetsAt && (w.usedPercent > 0 || w.severity !== "none");
+      const hasUsage = w.usedPercent > 0 || (w.usedValue != null && w.usedValue > 0);
+      const shouldShowReset = w.resetsAt && (hasUsage || w.severity !== "none");
       const resetTime = shouldShowReset ? formatFooterResetTime(w.resetsAt!) : "";
       const reset = resetTime ? theme.fg("dim", ` ${resetTime}`) : "";
       return `${core}${reset}`;


### PR DESCRIPTION
### Description
This PR improves the usage status footer formatting to make it significantly more compact and readable in narrow terminals and busy status bars.

### Changes
- Replace verbose `N% left` with `N%` for percentage windows
- Separate multiple window indicators with ` · ` for clear visual distinction
- Simplify reset time rendering to a concise parenthetical format `(2h 19m)`
- Only show the reset countdown when a quota has actually been consumed or is under risk
- Update unit tests in `format-status.test.ts`