### PR TITLE
fix: keep Grok quota visible at zero usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Grok quota visibility**: zero-usage billing periods now remain visible when xAI omits the zero-valued percentage, and billing requests include the required xAI token-auth marker.
+
 ## [0.5.0] - 2026-08-31
 
 ### Added

--- a/src/providers/fetch.test.ts
+++ b/src/providers/fetch.test.ts
@@ -9,6 +9,7 @@ import {
   fetchOllamaCloudQuotasWithToken,
   fetchOpenRouterQuotasWithToken,
   fetchSyntheticQuotas,
+  fetchXaiQuotas,
   fetchXaiQuotasWithToken,
 } from "./fetch.js";
 
@@ -475,9 +476,41 @@ describe("fetchXaiQuotasWithToken", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer xai-token",
+          "X-XAI-Token-Auth": "xai-grok-cli",
         }),
       }),
     );
+  });
+
+  it("resolves the native xAI credential from Pi auth storage", async () => {
+    const getApiKey = vi.fn(async (provider: string) =>
+      provider === "xai" ? "xai-access-token" : undefined,
+    );
+    const auth = { getApiKey } as unknown as AuthStorage;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          config: {
+            currentPeriod: {
+              type: "USAGE_PERIOD_TYPE_WEEKLY",
+              start: "2026-09-01T17:13:55Z",
+              end: "2026-09-08T17:13:55Z",
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    ) as any;
+
+    const result = await fetchXaiQuotas(auth);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.windows).toHaveLength(1);
+      expect(result.data.windows[0].usedPercent).toBe(0);
+    }
+    expect(getApiKey).toHaveBeenCalledOnce();
+    expect(getApiKey).toHaveBeenCalledWith("xai");
   });
 
   it("reports Grok billing HTTP failures", async () => {

--- a/src/providers/fetch.ts
+++ b/src/providers/fetch.ts
@@ -544,6 +544,7 @@ export async function fetchXaiQuotasWithToken(
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
+        "X-XAI-Token-Auth": "xai-grok-cli",
         Accept: "application/json",
       },
     },

--- a/src/providers/parse.test.ts
+++ b/src/providers/parse.test.ts
@@ -962,6 +962,27 @@ describe("parseXaiUsage", () => {
     });
   });
 
+  it("treats an omitted zero credit percentage as unused quota", () => {
+    const windows = parseXaiUsage({
+      config: {
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_WEEKLY",
+          start: "2026-09-01T17:13:55Z",
+          end: "2026-09-08T17:13:55Z",
+        },
+      },
+    });
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({
+      provider: "xai",
+      label: "Week (credits)",
+      usedPercent: 0,
+      usedValue: 0,
+      limitValue: 100,
+    });
+  });
+
   it("does not manufacture windows from missing or invalid limits", () => {
     expect(parseXaiUsage({})).toEqual([]);
     expect(

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -810,11 +810,11 @@ export function parseXaiUsage(data: any): QuotaWindow[] {
   const periodLabel = isWeekly ? "Week" : "Month";
   const windows: QuotaWindow[] = [];
 
-  const creditUsagePercent = Number(config.creditUsagePercent);
-  if (
-    config.creditUsagePercent != null &&
-    Number.isFinite(creditUsagePercent)
-  ) {
+  // The billing response omits protobuf scalar fields when their value is 0.
+  // A valid period without creditUsagePercent therefore means 0% used.
+  const creditUsagePercent =
+    config.creditUsagePercent == null ? 0 : Number(config.creditUsagePercent);
+  if (Number.isFinite(creditUsagePercent)) {
     windows.push({
       provider: "xai",
       label: `${periodLabel} (credits)`,


### PR DESCRIPTION
## Summary

- Treat an omitted creditUsagePercent as 0% when xAI returns a valid billing period, so Grok remains visible in /usage at the start of a cycle.
- Send the xAI token-auth marker required by the Grok billing endpoint.
- Verify the standalone path resolves the native xai credential from Pi auth storage; no companion plugin is used.

## Verification

I ran the following before opening this PR (CI will re-run all of these):

- [x] npm run typecheck
- [x] npm run lint
- [x] npm test (135 tests passed with host OpenCode Go credentials isolated)

## Checklist

- [x] Tests added or updated for behavioural changes
- [x] CHANGELOG.md updated (under Unreleased)
- [x] No secrets, tokens, or credentials in the diff
- [x] Commits follow the existing style (type: subject)