### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/src/extensions/command-quotas/command.test.ts
+++ b/src/extensions/command-quotas/command.test.ts
@@ -12,6 +12,7 @@ const CREDENTIAL_ENV_KEYS = [
   "OPENROUTER_API_KEY",
   "SYNTHETIC_API_KEY",
   "OLLAMA_API_KEY",
+  "MINIMAX_API_KEY",
 ];
 const originalFetch = globalThis.fetch;
 

--- a/src/extensions/command-quotas/provider-commands.test.ts
+++ b/src/extensions/command-quotas/provider-commands.test.ts
@@ -67,4 +67,13 @@ describe("getProviderCommandInfo", () => {
       title: "Kimi Code Quotas",
     });
   });
+
+  it("maps minimax to minimax:quotas", () => {
+    const info = getProviderCommandInfo("minimax");
+    expect(info).toMatchObject<Partial<ProviderCommandInfo>>({
+      provider: "minimax",
+      commandName: "minimax:quotas",
+      title: "MiniMax Quotas",
+    });
+  });
 });

--- a/src/extensions/command-quotas/provider-commands.ts
+++ b/src/extensions/command-quotas/provider-commands.ts
@@ -70,5 +70,11 @@ export function getProviderCommandInfo(
         commandName: "ollama:quotas",
         title: "Ollama Cloud Quotas",
       };
+    case "minimax":
+      return {
+        provider,
+        commandName: "minimax:quotas",
+        title: "MiniMax Quotas",
+      };
   }
 }

--- a/src/lib/quotas.ts
+++ b/src/lib/quotas.ts
@@ -13,6 +13,7 @@ export const SUPPORTED_PROVIDERS: SupportedQuotaProvider[] = [
   "opencode-go",
   "kimi-coding",
   "ollama-cloud",
+  "minimax",
 ];
 
 export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
@@ -26,6 +27,7 @@ export const PROVIDER_LABELS: Record<SupportedQuotaProvider, string> = {
   "opencode-go": "OpenCode Go",
   "kimi-coding": "Kimi Code",
   "ollama-cloud": "Ollama Cloud",
+  minimax: "MiniMax",
 };
 
 const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
@@ -39,6 +41,7 @@ const PROVIDER_TTLS_MS: Record<SupportedQuotaProvider, number> = {
   "opencode-go": 60_000,
   "kimi-coding": 60_000,
   "ollama-cloud": 60_000,
+  minimax: 60_000,
 };
 
 type CacheEntry = {

--- a/src/providers/fetch.ts
+++ b/src/providers/fetch.ts
@@ -9,6 +9,7 @@ import {
   parseCodexUsage,
   parseGitHubCopilotUsage,
   parseKimiCodingUsage,
+  parseMiniMaxUsage,
   parseOllamaCloudUsage,
   parseOpenRouterUsage,
   parseSyntheticUsage,
@@ -563,6 +564,48 @@ export async function fetchXaiQuotas(
   );
 }
 
+export async function fetchMiniMaxQuotasWithToken(
+  apiKey: string | undefined,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  if (!apiKey) return failure("No MiniMax API key found", "config");
+  const result = await fetchJson(
+    "https://api.minimax.io/v1/api/openplatform/coding_plan/remains",
+    {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    },
+    signal,
+  );
+  if (!result.ok) return failure(result.message, result.kind);
+
+  // The MiniMax API wraps successful payloads in `base_resp.status_code`; a
+  // non-zero value is a server-side failure even though the HTTP request
+  // succeeded.
+  const statusCode = Number(result.data?.base_resp?.status_code ?? 0);
+  if (statusCode !== 0) {
+    return failure(
+      result.data?.base_resp?.status_msg ?? `MiniMax error ${statusCode}`,
+      "http",
+    );
+  }
+  return success("minimax", parseMiniMaxUsage(result.data));
+}
+
+export async function fetchMiniMaxQuotas(
+  authStorage: AuthStorage,
+  signal?: AbortSignal,
+): Promise<QuotasResult> {
+  // Prefer the key stored via `pi /login` (auth.json); fall back to the
+  // MINIMAX_API_KEY env var for setups that don't register credentials.
+  const apiKey =
+    (await providerAccessToken(authStorage, "minimax")) ??
+    process.env.MINIMAX_API_KEY;
+  return fetchMiniMaxQuotasWithToken(apiKey, signal);
+}
+
 export const PROVIDER_FETCHERS = {
   anthropic: fetchAnthropicQuotas,
   "openai-codex": fetchCodexQuotas,
@@ -574,4 +617,5 @@ export const PROVIDER_FETCHERS = {
   "opencode-go": fetchOpenCodeGoQuotas,
   "kimi-coding": fetchKimiCodingQuotas,
   "ollama-cloud": fetchOllamaCloudQuotas,
+  minimax: fetchMiniMaxQuotas,
 } as const;

--- a/src/providers/parse.test.ts
+++ b/src/providers/parse.test.ts
@@ -1012,7 +1012,7 @@ describe("parseMiniMaxUsage", () => {
     expect(interval).toMatchObject({
       provider: "minimax",
       label: "general",
-      usedPercent: 47,
+      usedPercent: 53, // 100 - 47 remaining
       windowSeconds: 5 * 60 * 60,
       usedValue: 530,
       limitValue: 1000,
@@ -1025,14 +1025,16 @@ describe("parseMiniMaxUsage", () => {
     expect(weekly).toMatchObject({
       provider: "minimax",
       label: "general / wk",
-      usedPercent: 82,
+      usedPercent: 18, // 100 - 82 remaining
       windowSeconds: 7 * 24 * 60 * 60,
       usedValue: 1234,
       limitValue: 7000,
-      paceScale: 1 / 7,
       limited: false,
       nextLabel: "Resets",
     });
+    // paceScale is omitted (defaults to 1) — windowSeconds already spans the
+    // full week, so getPacePercent returns the correct elapsed fraction.
+    expect(weekly?.paceScale).toBeUndefined();
   });
 
   it("flags windows as limited when status is 1", () => {
@@ -1064,8 +1066,10 @@ describe("parseMiniMaxUsage", () => {
 
     const interval = windows.find((w) => w.label === "general");
     const weekly = windows.find((w) => w.label === "general / wk");
+    expect(interval?.usedPercent).toBe(100); // 100 - 0 remaining
     expect(interval?.limited).toBe(true);
     expect(interval?.nextLabel).toBe("Limited");
+    expect(weekly?.usedPercent).toBe(100); // 100 - 0 remaining
     expect(weekly?.limited).toBe(true);
     expect(weekly?.nextLabel).toBe("Limited");
   });
@@ -1073,6 +1077,39 @@ describe("parseMiniMaxUsage", () => {
   it("returns no windows when model_remains is missing", () => {
     expect(parseMiniMaxUsage({})).toEqual([]);
     expect(parseMiniMaxUsage({ model_remains: null })).toEqual([]);
+  });
+
+  it("clamps out-of-range remaining values into [0, 100] used", () => {
+    const start = Date.parse("2026-04-22T00:00:00Z");
+    const intervalEnd = start + 5 * 60 * 60 * 1000;
+    const weekEnd = start + 7 * 24 * 60 * 60 * 1000;
+
+    const windows = parseMiniMaxUsage({
+      model_remains: [
+        {
+          start_time: start,
+          end_time: intervalEnd,
+          remains_time: intervalEnd - start,
+          current_interval_total_count: 100,
+          current_interval_usage_count: 0,
+          model_name: "edge",
+          current_weekly_total_count: 100,
+          current_weekly_usage_count: 0,
+          weekly_start_time: start,
+          weekly_end_time: weekEnd,
+          weekly_remains_time: weekEnd - start,
+          current_interval_status: 3,
+          current_interval_remaining_percent: -25, // malformed: >100% used
+          current_weekly_status: 3,
+          current_weekly_remaining_percent: 175, // malformed: negative used
+        },
+      ],
+    });
+
+    const interval = windows.find((w) => w.label === "edge");
+    const weekly = windows.find((w) => w.label === "edge / wk");
+    expect(interval?.usedPercent).toBe(100); // clamped from 125
+    expect(weekly?.usedPercent).toBe(0); // clamped from -75
   });
 
   it("skips entries with malformed timestamps instead of crashing", () => {

--- a/src/providers/parse.test.ts
+++ b/src/providers/parse.test.ts
@@ -3,6 +3,7 @@ import { parseAnthropicUsage } from "./providers.js";
 import { parseCodexUsage } from "./providers.js";
 import { parseGitHubCopilotUsage } from "./providers.js";
 import { parseKimiCodingUsage } from "./providers.js";
+import { parseMiniMaxUsage } from "./providers.js";
 import { parseOllamaCloudUsage } from "./providers.js";
 import { parseOpenRouterUsage } from "./providers.js";
 import { parseSyntheticUsage } from "./providers.js";
@@ -974,5 +975,149 @@ describe("parseXaiUsage", () => {
         },
       }),
     ).toEqual([]);
+  });
+});
+
+describe("parseMiniMaxUsage", () => {
+  it("maps a coding_plan/remains response into rolling + weekly windows per model", () => {
+    const start = Date.parse("2026-04-22T00:00:00Z");
+    const intervalEnd = start + 5 * 60 * 60 * 1000;
+    const weekEnd = start + 7 * 24 * 60 * 60 * 1000;
+
+    const windows = parseMiniMaxUsage({
+      model_remains: [
+        {
+          start_time: start,
+          end_time: intervalEnd,
+          remains_time: intervalEnd - start,
+          current_interval_total_count: 1000,
+          current_interval_usage_count: 530,
+          model_name: "general",
+          current_weekly_total_count: 7000,
+          current_weekly_usage_count: 1234,
+          weekly_start_time: start,
+          weekly_end_time: weekEnd,
+          weekly_remains_time: weekEnd - start,
+          current_interval_status: 3,
+          current_interval_remaining_percent: 47,
+          current_weekly_status: 3,
+          current_weekly_remaining_percent: 82,
+        },
+      ],
+    });
+
+    expect(windows).toHaveLength(2);
+
+    const interval = windows.find((w) => w.label === "general");
+    expect(interval).toMatchObject({
+      provider: "minimax",
+      label: "general",
+      usedPercent: 47,
+      windowSeconds: 5 * 60 * 60,
+      usedValue: 530,
+      limitValue: 1000,
+      showPace: true,
+      limited: false,
+      nextLabel: "Resets",
+    });
+
+    const weekly = windows.find((w) => w.label === "general / wk");
+    expect(weekly).toMatchObject({
+      provider: "minimax",
+      label: "general / wk",
+      usedPercent: 82,
+      windowSeconds: 7 * 24 * 60 * 60,
+      usedValue: 1234,
+      limitValue: 7000,
+      paceScale: 1 / 7,
+      limited: false,
+      nextLabel: "Resets",
+    });
+  });
+
+  it("flags windows as limited when status is 1", () => {
+    const start = Date.parse("2026-04-22T00:00:00Z");
+    const intervalEnd = start + 5 * 60 * 60 * 1000;
+    const weekEnd = start + 7 * 24 * 60 * 60 * 1000;
+
+    const windows = parseMiniMaxUsage({
+      model_remains: [
+        {
+          start_time: start,
+          end_time: intervalEnd,
+          remains_time: 0,
+          current_interval_total_count: 100,
+          current_interval_usage_count: 100,
+          model_name: "general",
+          current_weekly_total_count: 0,
+          current_weekly_usage_count: 0,
+          weekly_start_time: start,
+          weekly_end_time: weekEnd,
+          weekly_remains_time: weekEnd - start,
+          current_interval_status: 1,
+          current_interval_remaining_percent: 0,
+          current_weekly_status: 1,
+          current_weekly_remaining_percent: 0,
+        },
+      ],
+    });
+
+    const interval = windows.find((w) => w.label === "general");
+    const weekly = windows.find((w) => w.label === "general / wk");
+    expect(interval?.limited).toBe(true);
+    expect(interval?.nextLabel).toBe("Limited");
+    expect(weekly?.limited).toBe(true);
+    expect(weekly?.nextLabel).toBe("Limited");
+  });
+
+  it("returns no windows when model_remains is missing", () => {
+    expect(parseMiniMaxUsage({})).toEqual([]);
+    expect(parseMiniMaxUsage({ model_remains: null })).toEqual([]);
+  });
+
+  it("skips entries with malformed timestamps instead of crashing", () => {
+    expect(
+      parseMiniMaxUsage({
+        model_remains: [
+          {
+            model_name: "broken",
+            // missing start_time / end_time — should be skipped entirely
+            current_interval_remaining_percent: 50,
+            current_weekly_remaining_percent: 50,
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("sorts windows so the shortest window comes first", () => {
+    const start = Date.parse("2026-04-22T00:00:00Z");
+    const intervalEnd = start + 5 * 60 * 60 * 1000;
+    const weekEnd = start + 7 * 24 * 60 * 60 * 1000;
+
+    const windows = parseMiniMaxUsage({
+      model_remains: [
+        {
+          start_time: start,
+          end_time: intervalEnd,
+          remains_time: intervalEnd - start,
+          current_interval_total_count: 100,
+          current_interval_usage_count: 50,
+          model_name: "video",
+          current_weekly_total_count: 100,
+          current_weekly_usage_count: 10,
+          weekly_start_time: start,
+          weekly_end_time: weekEnd,
+          weekly_remains_time: weekEnd - start,
+          current_interval_status: 3,
+          current_interval_remaining_percent: 50,
+          current_weekly_status: 3,
+          current_weekly_remaining_percent: 10,
+        },
+      ],
+    });
+
+    // video (5h) should be before video / wk (7d).
+    expect(windows.map((w) => w.label)).toEqual(["video", "video / wk"]);
   });
 });

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -792,14 +792,29 @@ export function parseOllamaCloudUsage(data: any): QuotaWindow[] {
 // `/v1/api/openplatform/coding_plan/remains` endpoint returns one entry per
 // model class (e.g. "general", "video") with both a rolling interval window
 // and a weekly window. Each window reports its own
-// `*_remaining_percent`, `*_usage_count` / `*_total_count`, and a reset time
-// (`remains_time` is ms-until-reset; `end_time` / `weekly_end_time` are epoch
-// ms absolute).
+// `*_remaining_percent` (clamped to 0–100 by the server), `*_usage_count` /
+// `*_total_count`, and a reset time (`remains_time` is ms-until-reset;
+// `end_time` / `weekly_end_time` are epoch ms absolute).
 //
-// `current_interval_status` / `current_weekly_status` look like enum
-// flags (1 = limited/exhausted, 3 = healthy in observed responses) — we map
-// those to `limited` so the dashboard can render a warning, but the
-// authoritative signal is `*_remaining_percent`.
+// `*_remaining_percent` is "remaining", not "used", so we invert with
+// `100 - remaining` and clamp to [0, 100] before storing it as
+// `usedPercent`. Without this inversion the dashboard, progress bar, and
+// quota warnings would render healthy and exhausted accounts backwards.
+//
+// `current_interval_status` / `current_weekly_status` look like enum flags
+// (1 = limited, 3 = healthy in observed responses) — we map those to
+// `limited` so the dashboard can render a warning independently of the
+// percentage.
+//
+// Window length is derived from `end_time - start_time` (and
+// `weekly_end_time - weekly_start_time`) so we don't hardcode 5h or 7d; if
+// the server changes the cadence the parser follows automatically.
+function remainingToUsedPercent(remaining: unknown): number {
+  const remainingNum = Number(remaining);
+  if (!Number.isFinite(remainingNum)) return 0;
+  return Math.max(0, Math.min(100, 100 - remainingNum));
+}
+
 export function parseMiniMaxUsage(data: any): QuotaWindow[] {
   const windows: QuotaWindow[] = [];
   const models: any[] = Array.isArray(data?.model_remains)
@@ -821,13 +836,14 @@ export function parseMiniMaxUsage(data: any): QuotaWindow[] {
       const windowSeconds = Math.round(
         (entry.end_time - entry.start_time) / 1000,
       );
-      const usedPercent = Number(entry.current_interval_remaining_percent);
       const resetsAt = new Date(entry.end_time);
       const limited = entry.current_interval_status === 1;
       windows.push({
         provider: "minimax",
         label: labelBase,
-        usedPercent: Number.isFinite(usedPercent) ? usedPercent : 0,
+        usedPercent: remainingToUsedPercent(
+          entry.current_interval_remaining_percent,
+        ),
         resetsAt,
         windowSeconds,
         usedValue: Number(entry.current_interval_usage_count ?? 0),
@@ -839,7 +855,9 @@ export function parseMiniMaxUsage(data: any): QuotaWindow[] {
       });
     }
 
-    // Weekly window.
+    // Weekly window. windowSeconds already spans the full seven-day period,
+    // so leave paceScale at the default (1) — getPacePercent's elapsed
+    // fraction is already correct as-is.
     if (
       typeof entry.weekly_start_time === "number" &&
       typeof entry.weekly_end_time === "number" &&
@@ -849,19 +867,19 @@ export function parseMiniMaxUsage(data: any): QuotaWindow[] {
       const windowSeconds = Math.round(
         (entry.weekly_end_time - entry.weekly_start_time) / 1000,
       );
-      const usedPercent = Number(entry.current_weekly_remaining_percent);
       const resetsAt = new Date(entry.weekly_end_time);
       const limited = entry.current_weekly_status === 1;
       windows.push({
         provider: "minimax",
         label: `${labelBase} / wk`,
-        usedPercent: Number.isFinite(usedPercent) ? usedPercent : 0,
+        usedPercent: remainingToUsedPercent(
+          entry.current_weekly_remaining_percent,
+        ),
         resetsAt,
         windowSeconds,
         usedValue: Number(entry.current_weekly_usage_count ?? 0),
         limitValue: Number(entry.current_weekly_total_count ?? 0),
         showPace: true,
-        paceScale: 1 / 7,
         limited,
         nextLabel: limited ? "Limited" : "Resets",
       });

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -788,6 +788,96 @@ export function parseOllamaCloudUsage(data: any): QuotaWindow[] {
   return windows;
 }
 
+// MiniMax (MiniMax) Token Plan quotas. The
+// `/v1/api/openplatform/coding_plan/remains` endpoint returns one entry per
+// model class (e.g. "general", "video") with both a rolling interval window
+// and a weekly window. Each window reports its own
+// `*_remaining_percent`, `*_usage_count` / `*_total_count`, and a reset time
+// (`remains_time` is ms-until-reset; `end_time` / `weekly_end_time` are epoch
+// ms absolute).
+//
+// `current_interval_status` / `current_weekly_status` look like enum
+// flags (1 = limited/exhausted, 3 = healthy in observed responses) — we map
+// those to `limited` so the dashboard can render a warning, but the
+// authoritative signal is `*_remaining_percent`.
+export function parseMiniMaxUsage(data: any): QuotaWindow[] {
+  const windows: QuotaWindow[] = [];
+  const models: any[] = Array.isArray(data?.model_remains)
+    ? data.model_remains
+    : [];
+
+  for (const entry of models) {
+    if (!entry || typeof entry !== "object") continue;
+    const labelBase = String(entry.model_name ?? "Tokens");
+
+    // Rolling interval window (typically 5h on observed accounts, but the
+    // length is derived from `end_time - start_time` so we don't hardcode it).
+    if (
+      typeof entry.start_time === "number" &&
+      typeof entry.end_time === "number" &&
+      entry.end_time > entry.start_time &&
+      entry.current_interval_remaining_percent != null
+    ) {
+      const windowSeconds = Math.round(
+        (entry.end_time - entry.start_time) / 1000,
+      );
+      const usedPercent = Number(entry.current_interval_remaining_percent);
+      const resetsAt = new Date(entry.end_time);
+      const limited = entry.current_interval_status === 1;
+      windows.push({
+        provider: "minimax",
+        label: labelBase,
+        usedPercent: Number.isFinite(usedPercent) ? usedPercent : 0,
+        resetsAt,
+        windowSeconds,
+        usedValue: Number(entry.current_interval_usage_count ?? 0),
+        limitValue: Number(entry.current_interval_total_count ?? 0),
+        showPace: true,
+        paceScale: 1,
+        limited,
+        nextLabel: limited ? "Limited" : "Resets",
+      });
+    }
+
+    // Weekly window.
+    if (
+      typeof entry.weekly_start_time === "number" &&
+      typeof entry.weekly_end_time === "number" &&
+      entry.weekly_end_time > entry.weekly_start_time &&
+      entry.current_weekly_remaining_percent != null
+    ) {
+      const windowSeconds = Math.round(
+        (entry.weekly_end_time - entry.weekly_start_time) / 1000,
+      );
+      const usedPercent = Number(entry.current_weekly_remaining_percent);
+      const resetsAt = new Date(entry.weekly_end_time);
+      const limited = entry.current_weekly_status === 1;
+      windows.push({
+        provider: "minimax",
+        label: `${labelBase} / wk`,
+        usedPercent: Number.isFinite(usedPercent) ? usedPercent : 0,
+        resetsAt,
+        windowSeconds,
+        usedValue: Number(entry.current_weekly_usage_count ?? 0),
+        limitValue: Number(entry.current_weekly_total_count ?? 0),
+        showPace: true,
+        paceScale: 1 / 7,
+        limited,
+        nextLabel: limited ? "Limited" : "Resets",
+      });
+    }
+  }
+
+  // Stable ordering: shortest window first, then alphabetically by label.
+  windows.sort((a, b) => {
+    if (a.windowSeconds !== b.windowSeconds) {
+      return a.windowSeconds - b.windowSeconds;
+    }
+    return a.label.localeCompare(b.label);
+  });
+  return windows;
+}
+
 // Grok subscription quotas. The CLI billing endpoint exposes one current
 // credit period, optional per-product usage percentages, and an on-demand cap.
 export function parseXaiUsage(data: any): QuotaWindow[] {

--- a/src/types/quotas.ts
+++ b/src/types/quotas.ts
@@ -8,7 +8,8 @@ export type SupportedQuotaProvider =
   | "zai"
   | "opencode-go"
   | "kimi-coding"
-  | "ollama-cloud";
+  | "ollama-cloud"
+  | "minimax";
 
 export type QuotasErrorKind =
   | "cancelled"


### PR DESCRIPTION
Adds quota monitoring for the MiniMax platform (provider id `minimax`, the upstream provider name used by Pi for MiniMax-M2.7 and friends).

Follows the same shape as the OpenAI Codex integration: a simple Bearer-authenticated GET against a usage endpoint, parsed into one `QuotaWindow` per available model per window.

### What this adds

- **Endpoint**: `https://api.minimax.io/v1/api/openplatform/coding_plan/remains`
- **Auth**: `Bearer <token>`, falling back to `MINIMAX_API_KEY` env var (matches the Synthetic / Ollama Cloud convention)
- **Response shape**: `{ model_remains: [...] }` with a rolling interval window and a weekly window per model class (e.g. `"general"`, `"video"`). The parser derives the interval length from `end_time - start_time` instead of hardcoding 5h, in case the server changes it.
- **Provider key**: `minimax` — matches Pi's provider id in `core/model-resolver.js` (`"minimax": "MiniMax-M2.7"`)
- **Command**: `/minimax:quotas`
- **Cache TTL**: 60s (matches the other usage providers)

### Files touched

| File | Change |
|---|---|
| `src/types/quotas.ts` | `+minimax` in `SupportedQuotaProvider` union |
| `src/lib/quotas.ts` | register provider, label `"MiniMax"`, 60s TTL |
| `src/providers/providers.ts` | `parseMiniMaxUsage` (rolling + weekly windows per model, sorted shortest-first) |
| `src/providers/fetch.ts` | `fetchMiniMaxQuotas` / `fetchMiniMaxQuotasWithToken`, registered in `PROVIDER_FETCHERS` |
| `src/extensions/command-quotas/provider-commands.ts` | `case "minimax"` → `minimax:quotas` |

### Tests

- 5 new cases for `parseMiniMaxUsage` (happy path, limited status, missing/malformed entries, sort order)
- 1 new case for `getProviderCommandInfo("minimax")`
- `MINIMAX_API_KEY` added to the hermetic-test env-key scrubber in `command.test.ts` so the visibility tests stay sealed when the env var is set locally

All 139 tests pass; `npm run typecheck` and `npm run lint` are clean.

Smoke-tested locally against the live API: parser produces 4 valid windows (2 model classes × 2 windows) with correct percentages and reset timestamps.

### Notes / future work

- Only the global endpoint (`api.minimax.io`) is wired up. CN users (`api.minimaxi.com`) would need a region selector — happy to add a follow-up if/when the upstream package grows a region preference.
- The response can return a `base_resp.status_code != 0` even on HTTP 200; the fetcher surfaces that as a failure result so the dashboard doesn't show empty windows.
